### PR TITLE
Optimize thruster tick performance

### DIFF
--- a/src/main/java/dev/devce/rocketnautics/content/blocks/BoosterThrusterBlockEntity.java
+++ b/src/main/java/dev/devce/rocketnautics/content/blocks/BoosterThrusterBlockEntity.java
@@ -27,6 +27,8 @@ import org.joml.Vector3d;
 import java.util.List;
 
 public class BoosterThrusterBlockEntity extends SmartBlockEntity implements BlockEntitySubLevelActor, IThruster, com.simibubi.create.api.equipment.goggles.IHaveGoggleInformation {
+    private static final long FUEL_SCAN_CACHE_TICKS = 5L;
+
     public ScrollValueBehaviour thrustPower;
     public int ignitionTicks = 0;
 
@@ -58,8 +60,8 @@ public class BoosterThrusterBlockEntity extends SmartBlockEntity implements Bloc
     }
 
     public static void tick(Level level, BlockPos pos, BlockState state, BoosterThrusterBlockEntity blockEntity) {
+        boolean active = blockEntity.isActive();
         if (!level.isClientSide) {
-            boolean active = blockEntity.isActive();
             if (active != blockEntity.currentlyBurning) {
                 blockEntity.currentlyBurning = active;
                 blockEntity.sendData();
@@ -71,7 +73,7 @@ public class BoosterThrusterBlockEntity extends SmartBlockEntity implements Bloc
         if (level.isClientSide()) {
             blockEntity.updateSound();
             
-            if (blockEntity.isActive()) {
+            if (active) {
                 BlockPos fuelPos = blockEntity.findFuelPos();
                 if (fuelPos != null) {
                     for (int i = 0; i < 2; i++) {
@@ -121,7 +123,7 @@ public class BoosterThrusterBlockEntity extends SmartBlockEntity implements Bloc
             }
         }
         
-        if (blockEntity.isActive()) {
+        if (active) {
             if (blockEntity.ignitionTicks < 100) blockEntity.ignitionTicks++;
         } else {
             if (blockEntity.ignitionTicks > 0) {
@@ -129,7 +131,7 @@ public class BoosterThrusterBlockEntity extends SmartBlockEntity implements Bloc
             }
         }
         
-        if (!level.isClientSide && blockEntity.isActive()) {
+        if (!level.isClientSide && active) {
             blockEntity.handleHeat();
             blockEntity.consumeFuel();
         }
@@ -144,7 +146,8 @@ public class BoosterThrusterBlockEntity extends SmartBlockEntity implements Bloc
         Vec3 end = start.add(nozzle.getStepX() * reach, nozzle.getStepY() * reach, nozzle.getStepZ() * reach);
         AABB damageArea = new AABB(start, end).inflate(0.5);
 
-        level.getEntitiesOfClass(LivingEntity.class, damageArea).forEach(entity -> {
+        List<LivingEntity> affectedEntities = level.getEntitiesOfClass(LivingEntity.class, damageArea);
+        affectedEntities.forEach(entity -> {
             if (entity.isAlive()) {
                 double pushStrength = (visualPower / 150.0);
                 entity.push(nozzle.getStepX() * pushStrength, nozzle.getStepY() * pushStrength, nozzle.getStepZ() * pushStrength);
@@ -172,7 +175,7 @@ public class BoosterThrusterBlockEntity extends SmartBlockEntity implements Bloc
                 if (targetState.isCollisionShapeFullBlock(level, targetPos)) break;
             }
 
-            level.getEntitiesOfClass(LivingEntity.class, damageArea).forEach(entity -> {
+            affectedEntities.forEach(entity -> {
                 if (entity.isAlive()) {
                     entity.hurt(level.damageSources().lava(), (float) (visualPower / 10.0));
                     entity.setRemainingFireTicks(entity.getRemainingFireTicks() + 40);
@@ -240,6 +243,9 @@ public class BoosterThrusterBlockEntity extends SmartBlockEntity implements Bloc
     private boolean ignited = false;
     private boolean isSpent = false;
     private int fuelTicks = 0;
+    private BlockPos cachedFuelPos = null;
+    private long cachedFuelPosTick = Long.MIN_VALUE;
+    private boolean fuelCacheValid = false;
 
     public boolean isActive() {
         if (level != null && level.isClientSide) return currentlyBurning;
@@ -280,6 +286,21 @@ public class BoosterThrusterBlockEntity extends SmartBlockEntity implements Bloc
     }
 
     private BlockPos findFuelPos() {
+        if (level != null) {
+            long gameTime = level.getGameTime();
+            if (fuelCacheValid && gameTime - cachedFuelPosTick <= FUEL_SCAN_CACHE_TICKS) {
+                return cachedFuelPos;
+            }
+        }
+
+        BlockPos scannedFuelPos = scanFuelPos();
+        cachedFuelPos = scannedFuelPos;
+        fuelCacheValid = true;
+        cachedFuelPosTick = level != null ? level.getGameTime() : Long.MIN_VALUE;
+        return scannedFuelPos;
+    }
+
+    private BlockPos scanFuelPos() {
         Direction nozzle = getThrustDirection();
         Direction back = nozzle.getOpposite();
         
@@ -335,7 +356,14 @@ public class BoosterThrusterBlockEntity extends SmartBlockEntity implements Bloc
         if (fuelPos != null) {
             level.setBlock(fuelPos, Blocks.AIR.defaultBlockState(), 3);
             fuelTicks = 200;
+            invalidateFuelCache();
         }
+    }
+
+    private void invalidateFuelCache() {
+        fuelCacheValid = false;
+        cachedFuelPos = null;
+        cachedFuelPosTick = Long.MIN_VALUE;
     }
 
     @Override
@@ -356,6 +384,7 @@ public class BoosterThrusterBlockEntity extends SmartBlockEntity implements Bloc
         isSpent = tag.getBoolean("Spent");
         fuelTicks = tag.getInt("FuelTicks");
         ignitionTicks = tag.getInt("IgnitionTicks");
+        invalidateFuelCache();
     }
 
     private void consumeFuel() {

--- a/src/main/java/dev/devce/rocketnautics/content/blocks/RCSThrusterBlockEntity.java
+++ b/src/main/java/dev/devce/rocketnautics/content/blocks/RCSThrusterBlockEntity.java
@@ -68,8 +68,8 @@ public class RCSThrusterBlockEntity extends RocketThrusterBlockEntity {
 
 
     public static void tick(Level level, BlockPos pos, BlockState state, RCSThrusterBlockEntity blockEntity) {
+        boolean active = blockEntity.isActive();
         if (!level.isClientSide) {
-            boolean active = blockEntity.isActive();
             if (active != blockEntity.currentlyBurning) {
                 blockEntity.currentlyBurning = active;
                 blockEntity.sendData();
@@ -79,7 +79,7 @@ public class RCSThrusterBlockEntity extends RocketThrusterBlockEntity {
         blockEntity.tick();
         
         if (level.isClientSide()) {
-            if (blockEntity.isActive()) {
+            if (active) {
                 Direction nozzle = blockEntity.getThrustDirection();
                 Vector3d pDir = new Vector3d(nozzle.getStepX(), nozzle.getStepY(), nozzle.getStepZ());
                 
@@ -99,7 +99,7 @@ public class RCSThrusterBlockEntity extends RocketThrusterBlockEntity {
             }
         }
         
-        if (blockEntity.isActive()) {
+        if (active) {
             if (blockEntity.ignitionTicks < 10) blockEntity.ignitionTicks++;
         } else {
             if (blockEntity.ignitionTicks > 0) blockEntity.ignitionTicks--;

--- a/src/main/java/dev/devce/rocketnautics/content/blocks/RocketThrusterBlockEntity.java
+++ b/src/main/java/dev/devce/rocketnautics/content/blocks/RocketThrusterBlockEntity.java
@@ -19,7 +19,6 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluids;
@@ -115,12 +114,12 @@ public class RocketThrusterBlockEntity extends SmartBlockEntity implements Block
         }
 
         blockEntity.tick();
+        boolean active = blockEntity.isActive();
         
         if (level.isClientSide()) {
             blockEntity.updateSound();
             
-            if (blockEntity.isActive()) {
-                Direction nozzle = blockEntity.getThrustDirection();
+            if (active) {
                 Vector3d pDir = blockEntity.getParticleDirection();
                 
                 double x = pos.getX() + 0.5 + pDir.x() * 0.7;
@@ -162,13 +161,13 @@ public class RocketThrusterBlockEntity extends SmartBlockEntity implements Block
             }
         }
         
-        if (blockEntity.isActive()) {
+        if (active) {
             if (blockEntity.ignitionTicks < 100) blockEntity.ignitionTicks++;
         } else {
             if (blockEntity.ignitionTicks > 0) blockEntity.ignitionTicks--;
         }
         
-        if (blockEntity.isActive()) {
+        if (active) {
             Direction nozzle = blockEntity.getThrustDirection();
             int power = blockEntity.getCurrentPower();
             int visualPower = (int)(power * 2.85f);
@@ -176,8 +175,9 @@ public class RocketThrusterBlockEntity extends SmartBlockEntity implements Block
             Vec3 start = Vec3.atCenterOf(pos).add(nozzle.getStepX() * 0.5, nozzle.getStepY() * 0.5, nozzle.getStepZ() * 0.5);
             Vec3 end = start.add(nozzle.getStepX() * reach, nozzle.getStepY() * reach, nozzle.getStepZ() * reach);
             AABB damageArea = new AABB(start, end).inflate(0.5);
-            
-            level.getEntitiesOfClass(LivingEntity.class, damageArea).forEach(entity -> {
+
+            List<LivingEntity> affectedEntities = level.getEntitiesOfClass(LivingEntity.class, damageArea);
+            affectedEntities.forEach(entity -> {
                 if (entity.isAlive()) {
                     double pushStrength = (visualPower / 150.0);
                     entity.push(nozzle.getStepX() * pushStrength, nozzle.getStepY() * pushStrength, nozzle.getStepZ() * pushStrength);
@@ -210,7 +210,7 @@ public class RocketThrusterBlockEntity extends SmartBlockEntity implements Block
                     if (targetState.isCollisionShapeFullBlock(level, targetPos)) break;
                 }
                 
-                level.getEntitiesOfClass(LivingEntity.class, damageArea).forEach(entity -> {
+                affectedEntities.forEach(entity -> {
                     if (entity.isAlive()) {
                         float damage = (float) (visualPower / 10.0);
                         entity.hurt(level.damageSources().lava(), damage);

--- a/src/main/java/dev/devce/rocketnautics/content/blocks/VectorThrusterBlockEntity.java
+++ b/src/main/java/dev/devce/rocketnautics/content/blocks/VectorThrusterBlockEntity.java
@@ -12,6 +12,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.joml.Vector3d;
 
 public class VectorThrusterBlockEntity extends RocketThrusterBlockEntity {
+    private static final Direction[] DIRECTIONS = Direction.values();
 
     private float gimbalX = 0;
     private float gimbalY = 0;
@@ -48,7 +49,7 @@ public class VectorThrusterBlockEntity extends RocketThrusterBlockEntity {
         float gY = 0;
         float gZ = 0;
         
-        for (Direction dir : Direction.values()) {
+        for (Direction dir : DIRECTIONS) {
             if (dir.getAxis() != nozzle.getAxis()) {
                 int signal = level.getSignal(worldPosition.relative(dir), dir);
                 gX += dir.getStepX() * signal * 0.02f;


### PR DESCRIPTION
### What changed
This PR focuses on reducing per-tick overhead in all thruster block entities while keeping gameplay behavior the same.

- Added short-lived caching for booster fuel-chain scanning so we don’t repeatedly scan the same fuel volume every tick.
- Reduced repeated `isActive()` checks in tick loops by computing it once and reusing it.
- Removed duplicate entity lookups in heat handling by querying nearby entities once and reusing the result for push + damage passes.
- Added a tiny loop optimization in vector thrusters by reusing a static direction array instead of calling `Direction.values()` repeatedly.

### Why this helps
Thrusters are high-frequency systems, so small repeated costs add up quickly.  
These changes cut redundant world/entity queries and repeated logic in hot paths, which should improve server-side tick stability and reduce unnecessary client work during sustained burns.

### Scope / risk
- No feature changes intended.
- No thrust values, heat values, or fuel behavior were intentionally altered.
- Changes are strictly performance-oriented and localized to thruster internals.

### Checklist
- [x] Rocket/Booster/RCS/Vector thrusters still ignite, thrust, and render normally.
- [x] Booster still consumes solid fuel chain correctly.
- [x] Heat push + burn behavior still applies as before.
- [x] No sync regressions between server active state and client effects/sound.