### PR TITLE
Add JEI and Jade to the development instance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,28 @@ repositories {
     maven {
         url 'https://maven.parchmentmc.org'
     }
+
+    // For JEI
+    maven {
+        name = "Progwml6's maven"
+        url = "https://maven.blamejared.com/"
+    }
+    maven {
+        name = "Jared's maven"
+        url = "https://maven.blamejared.com/"
+    }
+    maven {
+        name = "ModMaven"
+        url = "https://modmaven.dev"
+    }
+
+    // For Jade
+    maven {
+        url "https://www.cursemaven.com"
+        content {
+            includeGroup "curse.maven"
+        }
+    }
 }
 
 version = '1.3.2'
@@ -51,6 +73,13 @@ dependencies {
     
     // For now, I'll assume they are provided in a libs folder
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+
+    // JEI
+    compileOnly("mezz.jei:jei-1.21.1-common-api:${jei_version}")
+    compileOnly("mezz.jei:jei-1.21.1-neoforge-api:${jei_version}")
+    runtimeOnly("mezz.jei:jei-1.21.1-neoforge:${jei_version}")
+    // Jade
+    implementation "curse.maven:jade-324717:6738687"
 }
 
 sourceSets.main.resources { srcDir 'src/generated/resources' }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,5 @@ org.gradle.jvmargs=-Xmx2048M -Dsun.stdout.encoding=UTF-8
 org.gradle.parallel=true
 systemProp.org.gradle.internal.http.connectionTimeout=120000
 systemProp.org.gradle.internal.http.socketTimeout=120000
+
+jei_version=19.21.2.313


### PR DESCRIPTION
Adds JEI and Jade (tells you what block you're looking at) to the development instance. Both help with testing added content.