### PR TITLE
Dynamic scale planet render

### DIFF
--- a/src/main/java/dev/devce/rocketnautics/SkyDataHandler.java
+++ b/src/main/java/dev/devce/rocketnautics/SkyDataHandler.java
@@ -1,9 +1,24 @@
+/*
+ * This file is part of Cosmonautics.
+ * Cosmonautics is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cosmonautics is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cosmonautics.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package dev.devce.rocketnautics;
 
 import dev.devce.rocketnautics.content.physics.SpaceTransitionHandler;
 import dev.devce.rocketnautics.network.PlanetMapPayload;
 import it.unimi.dsi.fastutil.doubles.DoubleObjectPair;
-import it.unimi.dsi.fastutil.ints.IntObjectPair;
 import net.minecraft.core.Holder;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;

--- a/src/main/java/dev/devce/rocketnautics/SkyDataHandler.java
+++ b/src/main/java/dev/devce/rocketnautics/SkyDataHandler.java
@@ -1,9 +1,14 @@
 package dev.devce.rocketnautics;
 
+import dev.devce.rocketnautics.content.physics.SpaceTransitionHandler;
 import dev.devce.rocketnautics.network.PlanetMapPayload;
+import it.unimi.dsi.fastutil.doubles.DoubleObjectPair;
+import it.unimi.dsi.fastutil.ints.IntObjectPair;
 import net.minecraft.core.Holder;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.tags.BiomeTags;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.BiomeSource;
 import net.minecraft.world.level.biome.Climate;
@@ -22,6 +27,13 @@ public class SkyDataHandler {
 
     public static final Map<ServerLevel, SkyDataHandler> HANDLERS = new HashMap<>();
 
+    // level -> height offset, level to pull from
+    public static final Map<ResourceKey<Level>, DoubleObjectPair<ResourceKey<Level>>> OVERRIDES = new HashMap<>();
+
+    static {
+        OVERRIDES.put(SpaceTransitionHandler.SPACE_DIM, DoubleObjectPair.of(SpaceTransitionHandler.OVERWORLD_SPACE_Y, Level.OVERWORLD));
+    }
+
     public final ServerLevel level;
     protected final RecursiveDataSquare root;
 
@@ -31,7 +43,18 @@ public class SkyDataHandler {
         this.root = new RecursiveDataSquare(null, MAX_POWER_SIZE + 1, -MAX_TRUE_SIZE, -MAX_TRUE_SIZE);
     }
 
+    // client and server (used on client)
+    public static double getHeightOffsetForLevel(ResourceKey<Level> level) {
+        DoubleObjectPair<ResourceKey<Level>> pair = OVERRIDES.get(level);
+        if (pair == null) return 0;
+        return pair.firstDouble();
+    }
+
+    // server only
     public static SkyDataHandler getHandlerForLevel(ServerLevel level) {
+        if (OVERRIDES.containsKey(level.dimension())) {
+            level = level.getServer().getLevel(OVERRIDES.get(level.dimension()).right());
+        }
         return HANDLERS.computeIfAbsent(level, SkyDataHandler::new);
     }
 

--- a/src/main/java/dev/devce/rocketnautics/SkyDataHandler.java
+++ b/src/main/java/dev/devce/rocketnautics/SkyDataHandler.java
@@ -1,0 +1,240 @@
+package dev.devce.rocketnautics;
+
+import dev.devce.rocketnautics.network.PlanetMapPayload;
+import net.minecraft.core.Holder;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.tags.BiomeTags;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.BiomeSource;
+import net.minecraft.world.level.biome.Climate;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SkyDataHandler {
+
+    public static final int MAX_POWER_SIZE = 24;
+    public static final int MAX_TRUE_SIZE = 2 << MAX_POWER_SIZE; // approximately 30 million
+    public static final int MIN_POWER_SIZE = 14;
+
+    public static final int SCALE_FACTOR = 3;
+
+    public static final Map<ServerLevel, SkyDataHandler> HANDLERS = new HashMap<>();
+
+    public final ServerLevel level;
+    protected final RecursiveDataSquare root;
+
+    public SkyDataHandler(ServerLevel level) {
+        this.level = level;
+        // root is never rendered, only its four children may be rendered at once.
+        this.root = new RecursiveDataSquare(null, MAX_POWER_SIZE + 1, -MAX_TRUE_SIZE, -MAX_TRUE_SIZE);
+    }
+
+    public static SkyDataHandler getHandlerForLevel(ServerLevel level) {
+        return HANDLERS.computeIfAbsent(level, SkyDataHandler::new);
+    }
+
+    public PlanetMapPayload getRenderDataAtScaleAndPosition(int powerSize, int trueX, int trueZ) {
+        // get the square we are on
+        DataSquare square = getSquareAtPosition(powerSize, trueX, trueZ);
+        // get the nearest four squares
+        boolean posX = square.isPosX(trueX);
+        boolean posZ = square.isPosZ(trueZ);
+        DataSquare posXPosZ;
+        DataSquare posXNegZ;
+        DataSquare negXPosZ;
+        DataSquare negXNegZ;
+        int shift = toTrueSize(square.powerSize);
+        if (posX) {
+            if (posZ) {
+                negXNegZ = square;
+
+                posXPosZ = getSquareAtPosition(powerSize, trueX + shift, trueZ + shift);
+                posXNegZ = getSquareAtPosition(powerSize, trueX + shift, trueZ);
+                negXPosZ = getSquareAtPosition(powerSize, trueX, trueZ + shift);
+            } else {
+                negXPosZ = square;
+
+                posXPosZ = getSquareAtPosition(powerSize, trueX + shift, trueZ);
+                posXNegZ = getSquareAtPosition(powerSize, trueX + shift, trueZ - shift);
+                negXNegZ = getSquareAtPosition(powerSize, trueX, trueZ - shift);
+            }
+        } else {
+            if (posZ) {
+                posXNegZ = square;
+
+                posXPosZ = getSquareAtPosition(powerSize, trueX, trueZ + shift);
+                negXPosZ = getSquareAtPosition(powerSize, trueX - shift, trueZ + shift);
+                negXNegZ = getSquareAtPosition(powerSize, trueX - shift, trueZ);
+            } else {
+                posXPosZ = square;
+
+                posXNegZ = getSquareAtPosition(powerSize, trueX, trueZ - shift);
+                negXPosZ = getSquareAtPosition(powerSize, trueX - shift, trueZ);
+                negXNegZ = getSquareAtPosition(powerSize, trueX - shift, trueZ - shift);
+            }
+        }
+
+
+        return new PlanetMapPayload(square.powerSize, posXPosZ.trueNegXCorner, posXPosZ.trueNegZCorner, posXPosZ.getRenderData(), posXNegZ.getRenderData(), negXPosZ.getRenderData(), negXNegZ.getRenderData());
+    }
+
+    protected DataSquare getSquareAtPosition(int powerSize, int trueX, int trueZ) {
+        DataSquare square = root;
+        do { // we never render the root, so always descend one step before checking powerSize.
+            if (square instanceof RecursiveDataSquare r) {
+                square = r.getChildAtTruePosition(trueX, trueZ);
+            } else {
+                break;
+            }
+        } while (powerSize < square.powerSize);
+        return square;
+    }
+
+    public static int targetSizeForHeight(double y) {
+        int log2Height = (int) (Math.log(y) / Math.log(2));
+        return Math.clamp(log2Height + SCALE_FACTOR, MIN_POWER_SIZE, MAX_POWER_SIZE);
+    }
+
+    public static double targetSizeForHeightContinuous(double y) {
+        double log2Height = Math.log(y) / Math.log(2);
+        return Math.clamp(log2Height + SCALE_FACTOR, MIN_POWER_SIZE, MAX_POWER_SIZE);
+    }
+
+    public static int toTrueSize(int powerSize) {
+        return 2 << powerSize;
+    }
+
+    protected class RecursiveDataSquare extends DataSquare {
+        private DataSquare childPosXPosZ;
+        private DataSquare childPosXNegZ;
+        private DataSquare childNegXPosZ;
+        private DataSquare childNegXNegZ;
+
+        public RecursiveDataSquare(@Nullable RecursiveDataSquare parent, int powerSize, int trueNegXCorner, int trueNegZCorner) {
+            super(parent, powerSize, trueNegXCorner, trueNegZCorner);
+        }
+
+        public DataSquare getChildAtTruePosition(int trueX, int trueZ) {
+            boolean posX = isPosX(trueX);
+            boolean posZ = isPosZ(trueZ);
+            if (posX) {
+                if (posZ) {
+                    return getChildPosXPosZ();
+                } else {
+                    return getChildPosXNegZ();
+                }
+            } else {
+                if (posZ) {
+                    return getChildNegXPosZ();
+                } else {
+                    return getChildNegXNegZ();
+                }
+            }
+        }
+
+        private DataSquare createChild(int trueNegXCorner, int trueNegZCorner) {
+            if (powerSize > MIN_POWER_SIZE + 1) {
+                return new RecursiveDataSquare(this, powerSize - 1, trueNegXCorner, trueNegZCorner);
+            }
+            return new DataSquare(this, powerSize - 1, trueNegXCorner, trueNegZCorner);
+        }
+
+        public DataSquare getChildNegXNegZ() {
+            if (childNegXNegZ == null) {
+                childNegXNegZ = createChild(trueNegXCorner, trueNegZCorner);
+            }
+            return childNegXNegZ;
+        }
+
+        public DataSquare getChildNegXPosZ() {
+            if (childNegXPosZ == null) {
+                childNegXPosZ = createChild(trueNegXCorner, trueNegZCorner + toTrueSize(powerSize - 1));
+            }
+            return childNegXPosZ;
+        }
+
+        public DataSquare getChildPosXNegZ() {
+            if (childPosXNegZ == null) {
+                childPosXNegZ = createChild(trueNegXCorner + toTrueSize(powerSize - 1), trueNegZCorner);
+            }
+            return childPosXNegZ;
+        }
+
+        public DataSquare getChildPosXPosZ() {
+            if (childPosXPosZ == null) {
+                childPosXPosZ = createChild(trueNegXCorner + toTrueSize(powerSize - 1), trueNegZCorner + toTrueSize(powerSize - 1));
+            }
+            return childPosXPosZ;
+        }
+    }
+
+    protected class DataSquare {
+        public final @Nullable RecursiveDataSquare parent;
+        public final int powerSize;
+        public final int trueNegXCorner;
+        public final int trueNegZCorner;
+
+        protected byte[] renderData;
+
+        public DataSquare(@Nullable RecursiveDataSquare parent, int powerSize, int trueNegXCorner, int trueNegZCorner) {
+            this.parent = parent;
+            this.powerSize = powerSize;
+            this.trueNegXCorner = trueNegXCorner;
+            this.trueNegZCorner = trueNegZCorner;
+        }
+
+        public byte[] getRenderData() {
+            if (renderData == null) {
+                buildRenderData();
+            }
+            return renderData;
+        }
+
+        public boolean isPosX(int trueX) {
+            return trueX - trueNegXCorner >= toTrueSize(powerSize - 1);
+        }
+
+        public boolean isPosZ(int trueZ) {
+            return trueZ - trueNegZCorner >= toTrueSize(powerSize - 1);
+        }
+
+        protected byte biomeToData(Holder<Biome> biome) {
+            byte colorIdx = 4; // Default plains/grass
+            if (biome.is(BiomeTags.IS_OCEAN) || biome.is(BiomeTags.IS_DEEP_OCEAN)) colorIdx = 0;
+            else if (biome.is(BiomeTags.IS_RIVER)) colorIdx = 1;
+            else if (biome.is(BiomeTags.IS_BEACH)) colorIdx = 2;
+            else if (biome.is(BiomeTags.HAS_DESERT_PYRAMID)) colorIdx = 3;
+            else if (biome.is(BiomeTags.IS_FOREST)) colorIdx = 5;
+            else if (biome.is(BiomeTags.IS_JUNGLE)) colorIdx = 6;
+            else if (biome.is(BiomeTags.IS_TAIGA)) colorIdx = 7;
+            else if (biome.is(BiomeTags.HAS_VILLAGE_SNOWY)) colorIdx = 8;
+            else if (biome.is(BiomeTags.IS_BADLANDS)) colorIdx = 9;
+            else if (biome.is(BiomeTags.IS_MOUNTAIN)) colorIdx = 10;
+            return colorIdx;
+        }
+
+        protected void buildRenderData() {
+            renderData = new byte[256 * 256];
+            try {
+                BiomeSource source = level.getChunkSource().getGenerator().getBiomeSource();
+                Climate.Sampler sampler = level.getChunkSource().randomState().sampler();
+
+                int step = toTrueSize(powerSize - 8); // -8 is equivalent to /256
+
+                for (int x = 0; x < 256; x++) {
+                    for (int z = 0; z < 256; z++) {
+                        int worldX = trueNegXCorner + x * step;
+                        int worldZ = trueNegZCorner + z * step;
+
+                        Holder<Biome> biome = source.getNoiseBiome(worldX >> 2, 64 >> 2, worldZ >> 2, sampler);
+                        renderData[x + z * 256] = biomeToData(biome);
+                    }
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/dev/devce/rocketnautics/client/PlanetRenderInfo.java
+++ b/src/main/java/dev/devce/rocketnautics/client/PlanetRenderInfo.java
@@ -1,0 +1,51 @@
+package dev.devce.rocketnautics.client;
+
+import net.minecraft.client.renderer.texture.DynamicTexture;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.Objects;
+
+public final class PlanetRenderInfo {
+    private final ResourceLocation texID;
+    private final DynamicTexture texture;
+    private int powerSize;
+    private int centerX;
+    private int centerZ;
+
+    public PlanetRenderInfo(ResourceLocation texID, DynamicTexture texture) {
+        this.texID = texID;
+        this.texture = texture;
+    }
+
+    public ResourceLocation getTexID() {
+        return texID;
+    }
+
+    public DynamicTexture getTexture() {
+        return texture;
+    }
+
+    public int getPowerSize() {
+        return powerSize;
+    }
+
+    public int getCenterX() {
+        return centerX;
+    }
+
+    public int getCenterZ() {
+        return centerZ;
+    }
+
+    public void setPowerSize(int powerSize) {
+        this.powerSize = powerSize;
+    }
+
+    public void setCenterX(int centerX) {
+        this.centerX = centerX;
+    }
+
+    public void setCenterZ(int centerZ) {
+        this.centerZ = centerZ;
+    }
+}

--- a/src/main/java/dev/devce/rocketnautics/client/SkyHandler.java
+++ b/src/main/java/dev/devce/rocketnautics/client/SkyHandler.java
@@ -48,7 +48,7 @@ public class SkyHandler {
         if (mc.level == null || mc.player == null) return;
 
         Camera camera = mc.gameRenderer.getMainCamera();
-        double camY = camera.getPosition().y;
+        double camY = camera.getPosition().y + SkyDataHandler.getHeightOffsetForLevel(mc.level.dimension());
         if (camY < 1000.0) return;
 
         float visibility = (float) Mth.clamp((camY - 1000.0) / 500.0, 0.0, 1.0);
@@ -64,7 +64,7 @@ public class SkyHandler {
         invRot.conjugate();
         poseStack.mulPose(invRot);
 
-        float renderDist = 20.0f;
+        int renderDist = mc.options.renderDistance().get();
         float parallaxFactor = (float) (renderDist / Math.max(100.0, camY)); 
         double camX = camera.getPosition().x;
         double camZ = camera.getPosition().z;

--- a/src/main/java/dev/devce/rocketnautics/client/SkyHandler.java
+++ b/src/main/java/dev/devce/rocketnautics/client/SkyHandler.java
@@ -1,3 +1,19 @@
+/*
+ * This file is part of Cosmonautics.
+ * Cosmonautics is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cosmonautics is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cosmonautics.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package dev.devce.rocketnautics.client;
 
 import com.mojang.blaze3d.platform.GlStateManager;

--- a/src/main/java/dev/devce/rocketnautics/client/SkyHandler.java
+++ b/src/main/java/dev/devce/rocketnautics/client/SkyHandler.java
@@ -1,19 +1,3 @@
-/*
- * This file is part of Cosmonautics.
- * Cosmonautics is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Cosmonautics is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with Cosmonautics.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package dev.devce.rocketnautics.client;
 
 import com.mojang.blaze3d.platform.GlStateManager;
@@ -21,6 +5,7 @@ import com.mojang.blaze3d.platform.NativeImage;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 import dev.devce.rocketnautics.RocketNautics;
+import dev.devce.rocketnautics.SkyDataHandler;
 import dev.devce.rocketnautics.network.PlanetMapRequestPayload;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
@@ -39,26 +24,13 @@ import org.joml.Quaternionf;
 
 @EventBusSubscriber(modid = RocketNautics.MODID, bus = EventBusSubscriber.Bus.GAME, value = Dist.CLIENT)
 public class SkyHandler {
-    
-    private static final double OVERWORLD_SPACE_Y = 20000.0;
-
-    private static double getEffectiveY() {
-        Minecraft mc = Minecraft.getInstance();
-        if (mc.level == null) return 0;
-        double y = mc.gameRenderer.getMainCamera().getPosition().y;
-        ResourceLocation dim = mc.level.dimension().location();
-        if (dim.getNamespace().equals(RocketNautics.MODID) && dim.getPath().equals("space")) {
-            return OVERWORLD_SPACE_Y + y;
-        }
-        return y;
-    }
 
     @SubscribeEvent
     public static void onComputeFogColor(ViewportEvent.ComputeFogColor event) {
         Minecraft mc = Minecraft.getInstance();
         if (mc.level == null || mc.player == null) return;
 
-        double y = getEffectiveY();
+        double y = mc.gameRenderer.getMainCamera().getPosition().y;
         if (y > 1000.0) {
             float factor = (float) Mth.clamp((y - 1000.0) / 1000.0, 0.0, 1.0);
             
@@ -74,8 +46,9 @@ public class SkyHandler {
         
         Minecraft mc = Minecraft.getInstance();
         if (mc.level == null || mc.player == null) return;
-        
-        double camY = getEffectiveY();
+
+        Camera camera = mc.gameRenderer.getMainCamera();
+        double camY = camera.getPosition().y;
         if (camY < 1000.0) return;
 
         float visibility = (float) Mth.clamp((camY - 1000.0) / 500.0, 0.0, 1.0);
@@ -83,8 +56,6 @@ public class SkyHandler {
 
         PoseStack poseStack = event.getPoseStack();
         poseStack.pushPose();
-        
-        Camera camera = mc.gameRenderer.getMainCamera();
 
         Matrix4f matrix = poseStack.last().pose();
         matrix.identity();
@@ -92,36 +63,48 @@ public class SkyHandler {
         Quaternionf invRot = new Quaternionf(camera.rotation());
         invRot.conjugate();
         poseStack.mulPose(invRot);
-        
+
         float renderDist = 20.0f;
         float parallaxFactor = (float) (renderDist / Math.max(100.0, camY)); 
         double camX = camera.getPosition().x;
         double camZ = camera.getPosition().z;
-        float relX = (float) (-camX * parallaxFactor);
-        float relY = -renderDist;
-        float relZ = (float) (-camZ * parallaxFactor);
-        
-        float size = (float) (500000.0f * (renderDist / Math.max(100.0, camY)));
 
-        // OpenGL Magic: Temporary Infinite Projection Matrix to bypass far clipping
-        // without changing the object's size or distance.
-        Matrix4f oldProj = RenderSystem.getProjectionMatrix();
-        Matrix4f infiniteProj = new Matrix4f(oldProj);
-        // m22 = -(f+n)/(f-n) -> -1.0 as f -> infinity
-        // m32 = -2fn/(f-n)   -> -2.0*n as f -> infinity (n = 0.05 in MC)
-        infiniteProj.m22(-1.0f);
-        infiniteProj.m32(-0.1f);
-        RenderSystem.setProjectionMatrix(infiniteProj, RenderSystem.getVertexSorting());
-        
-        ensurePlanetTexture();
-        
+        ensurePlanetTexObj();
+        ensureCloudTexture();
+        ensureHaloTexture();
+        updatePlanetTex(camX, camY, camZ);
+        // move towards our most recently received texture
+        if (texFade > 0) {
+            texFade = Math.max(0, texFade - event.getPartialTick().getRealtimeDeltaTicks() / 20);
+        }
+        renderPlanet(PLANET_TEXTURE_OBJ_LAST, camX, camY, camZ, renderDist, parallaxFactor, matrix, texFade * visibility);
+        renderPlanet(PLANET_TEXTURE_OBJ, camX, camY, camZ, renderDist, parallaxFactor, matrix, (1 - texFade) * visibility);
+        poseStack.popPose();
+    }
+
+    private static void renderPlanet(PlanetRenderInfo planet, double camX, double camY, double camZ, float renderDist, float parallaxFactor, Matrix4f matrix, float visibility) {
+        if (visibility <= 0) return;
+        float relX = (float) ((planet.getCenterX() - camX) * parallaxFactor);
+        float relY = -renderDist;
+        float relZ = (float) ((planet.getCenterZ() - camZ) * parallaxFactor);
+
+        float prettyness = computePrettyness(planet, camY);
+        // shift toward zero
+        relX = Mth.lerp(prettyness, relX, 0);
+        relZ = Mth.lerp(prettyness, relZ, 0);
+        // move towards optimal size ratio
+        double trueSize = SkyDataHandler.toTrueSize(planet.getPowerSize());
+        double optimalSize = camY * (2 << SkyDataHandler.SCALE_FACTOR);
+        double result = Math.min(prettyness > 0 ? optimalSize : trueSize, SkyDataHandler.toTrueSize(SkyDataHandler.MAX_POWER_SIZE));
+        float size = (float) (result * (renderDist / Math.max(100.0, camY)));
+
         RenderSystem.enableBlend();
         RenderSystem.defaultBlendFunc();
         RenderSystem.depthMask(false);
         RenderSystem.disableDepthTest();
         RenderSystem.setShader(GameRenderer::getPositionTexColorShader);
-        if (PLANET_TEXTURE_ID != null) {
-            RenderSystem.setShaderTexture(0, PLANET_TEXTURE_ID);
+        if (planet.getTexID() != null) {
+            RenderSystem.setShaderTexture(0, planet.getTexID());
         } else {
             RenderSystem.setShaderTexture(0, ResourceLocation.fromNamespaceAndPath(RocketNautics.MODID, "textures/environment/planet_map.png"));
         }
@@ -129,27 +112,26 @@ public class SkyHandler {
 
         Tesselator tesselator = Tesselator.getInstance();
         BufferBuilder bufferbuilder = tesselator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX_COLOR);
-        
+
         float r = 1.0f, g = 1.0f, b = 1.0f;
-        
+
         RenderSystem.disableDepthTest();
         RenderSystem.depthMask(false);
-        
+
         bufferbuilder.addVertex(matrix, relX - size, relY, relZ - size).setColor(r, g, b, visibility).setUv(0.0f, 0.0f);
         bufferbuilder.addVertex(matrix, relX - size, relY, relZ + size).setColor(r, g, b, visibility).setUv(0.0f, 1.0f);
         bufferbuilder.addVertex(matrix, relX + size, relY, relZ + size).setColor(r, g, b, visibility).setUv(1.0f, 1.0f);
         bufferbuilder.addVertex(matrix, relX + size, relY, relZ - size).setColor(r, g, b, visibility).setUv(1.0f, 0.0f);
 
         BufferUploader.drawWithShader(bufferbuilder.buildOrThrow());
-        
-        ensureCloudTexture();
+
         if (CLOUD_TEXTURE_ID != null) {
             RenderSystem.enableBlend();
             RenderSystem.defaultBlendFunc();
             RenderSystem.setShaderTexture(0, CLOUD_TEXTURE_ID);
-            
-            float timeOffset = (System.currentTimeMillis() % 2000000L) / 100000.0f;
-            
+            long factor = 1000L * SkyDataHandler.toTrueSize(planet.getPowerSize() / 2);
+            float timeOffset = (System.currentTimeMillis() % (20L * factor)) / (float) factor;
+
             BufferBuilder cloudBuilder = tesselator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX_COLOR);
             cloudBuilder.addVertex(matrix, relX - size, relY, relZ - size).setColor(1.0f, 1.0f, 1.0f, visibility).setUv(0.0f + timeOffset, 0.0f);
             cloudBuilder.addVertex(matrix, relX - size, relY, relZ + size).setColor(1.0f, 1.0f, 1.0f, visibility).setUv(0.0f + timeOffset, 1.0f);
@@ -158,12 +140,11 @@ public class SkyHandler {
             BufferUploader.drawWithShader(cloudBuilder.buildOrThrow());
         }
 
-        ensureHaloTexture();
         if (HALO_TEXTURE_ID != null) {
             RenderSystem.enableBlend();
             RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE);
             RenderSystem.setShaderTexture(0, HALO_TEXTURE_ID);
-            
+
             float haloSize = size * 1.3f;
             BufferBuilder haloBuilder = tesselator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX_COLOR);
             haloBuilder.addVertex(matrix, relX - haloSize, relY, relZ - haloSize).setColor(1.0f, 1.0f, 1.0f, visibility).setUv(0.0f, 0.0f);
@@ -171,16 +152,14 @@ public class SkyHandler {
             haloBuilder.addVertex(matrix, relX + haloSize, relY, relZ + haloSize).setColor(1.0f, 1.0f, 1.0f, visibility).setUv(1.0f, 1.0f);
             haloBuilder.addVertex(matrix, relX + haloSize, relY, relZ - haloSize).setColor(1.0f, 1.0f, 1.0f, visibility).setUv(1.0f, 0.0f);
             BufferUploader.drawWithShader(haloBuilder.buildOrThrow());
-            
+
             RenderSystem.defaultBlendFunc();
         }
 
-        RenderSystem.setProjectionMatrix(oldProj, RenderSystem.getVertexSorting());
         RenderSystem.enableDepthTest();
         RenderSystem.depthMask(true);
         RenderSystem.enableCull();
         RenderSystem.disableBlend();
-        poseStack.popPose();
     }
 
     @SubscribeEvent
@@ -188,7 +167,7 @@ public class SkyHandler {
         Minecraft mc = Minecraft.getInstance();
         if (mc.level == null || mc.player == null) return;
         
-        double y = getEffectiveY();
+        double y = mc.gameRenderer.getMainCamera().getPosition().y;
         if (y > 1000.0) {
             float factor = (float) Mth.clamp((y - 1000.0) / 1000.0, 0.0, 1.0);
             
@@ -201,48 +180,113 @@ public class SkyHandler {
         }
     }
 
-    private static ResourceLocation PLANET_TEXTURE_ID = null;
-    private static DynamicTexture PLANET_TEXTURE_OBJ = null;
-    private static boolean mapRequested = false;
+    private static PlanetRenderInfo PLANET_TEXTURE_OBJ_LAST = null;
+    private static PlanetRenderInfo PLANET_TEXTURE_OBJ = null;
+    private static float texFade = 0;
+    private static boolean awaitUpdate = false;
 
-    private static void ensurePlanetTexture() {
-        if (PLANET_TEXTURE_ID != null) return;
-        Minecraft mc = Minecraft.getInstance();
-        
-        int size = 1024;
-        NativeImage image = new NativeImage(size, size, false);
-        
-        for (int x = 0; x < size; x++) {
-            for (int y = 0; y < size; y++) {
-                int color = (255 << 24) | (80 << 16) | (40 << 8) | 10;
-                image.setPixelRGBA(x, y, color);
-            }
-        }
-        
-        PLANET_TEXTURE_OBJ = new DynamicTexture(image);
-        PLANET_TEXTURE_ID = mc.getTextureManager().register("rocketnautics_planet", PLANET_TEXTURE_OBJ);
-        PLANET_TEXTURE_OBJ.setFilter(true, false);
-
-        
-        if (!mapRequested) {
-            PacketDistributor.sendToServer(new PlanetMapRequestPayload());
-            mapRequested = true;
+    /**
+     *
+     * @return the level of interpolation to "prettyness" based on the render scale clamp.
+     * 0f means that the planet should be rendered exactly as configured by the static fields.
+     * 1f means that the planet should be centered on (0, 0) and resized so that the length from center to edge is
+     * {@link SkyDataHandler#SCALE_FACTOR} powers of two larger than the player's current height.
+     * Note - size should still not exceed maximum size set in {@link SkyDataHandler}
+     */
+    private static float computePrettyness(PlanetRenderInfo planet, double camY) {
+        double continuousSize = SkyDataHandler.targetSizeForHeightContinuous(camY);
+        if (continuousSize <= getMaximumScale() || continuousSize <= planet.getPowerSize()) {
+            return 0;
+        } else if (continuousSize >= SkyDataHandler.MAX_POWER_SIZE) {
+            // ensure we are completely centered at (0, 0) once our target size is large enough.
+            // if clamping never kicks in, the final set of squares is centered at (0, 0) as well.
+            return 1;
+        } else {
+            return (float) (1 - 1 / (1 + continuousSize - planet.getPowerSize()));
         }
     }
 
-    public static void updatePlanetTexture(byte[] data) {
+    private static int getMaximumScale() {
+        // TODO config to clamp the maximum powerSize
+        // 15 is the recommended clamp
+        return 100;
+    }
+
+    private static void updatePlanetTex(double camX, double camY, double camZ) {
+        if (awaitUpdate) return;
+        // check if we've moved far enough to need to refresh our data
+        boolean clamped = SkyDataHandler.targetSizeForHeightContinuous(camY) > getMaximumScale();
+        double currentSize = clamped ? camY * (2 << SkyDataHandler.SCALE_FACTOR) : SkyDataHandler.toTrueSize(PLANET_TEXTURE_OBJ.getPowerSize());
+        boolean violateX = Math.abs(camX - PLANET_TEXTURE_OBJ.getCenterX()) > currentSize * 3/5;
+        boolean violateZ = Math.abs(camZ - PLANET_TEXTURE_OBJ.getCenterZ()) > currentSize * 3/5;
+        boolean violateScale = PLANET_TEXTURE_OBJ.getPowerSize() != Math.min(SkyDataHandler.targetSizeForHeight(camY), getMaximumScale());
+        if (violateX || violateZ || violateScale) {
+            awaitUpdate = true;
+            PacketDistributor.sendToServer(new PlanetMapRequestPayload(SkyDataHandler.targetSizeForHeight(camY)));
+        }
+    }
+
+    private static void ensurePlanetTexObj() {
+        if (PLANET_TEXTURE_OBJ == null) {
+            Minecraft mc = Minecraft.getInstance();
+
+            int size = 1024;
+            NativeImage image = new NativeImage(size, size, false);
+
+            for (int x = 0; x < size; x++) {
+                for (int y = 0; y < size; y++) {
+                    int color = (255 << 24) | (80 << 16) | (40 << 8) | 10;
+                    image.setPixelRGBA(x, y, color);
+                }
+            }
+
+            DynamicTexture tex = new DynamicTexture(image);
+            ResourceLocation id = mc.getTextureManager().register("rocketnautics_planet", tex);
+            tex.setFilter(true, false);
+            PLANET_TEXTURE_OBJ = new PlanetRenderInfo(id, tex);
+        }
+        if (PLANET_TEXTURE_OBJ_LAST == null) {
+            Minecraft mc = Minecraft.getInstance();
+
+            int size = 1024;
+            NativeImage image = new NativeImage(size, size, false);
+
+            for (int x = 0; x < size; x++) {
+                for (int y = 0; y < size; y++) {
+                    int color = (255 << 24) | (80 << 16) | (40 << 8) | 10;
+                    image.setPixelRGBA(x, y, color);
+                }
+            }
+
+            DynamicTexture tex = new DynamicTexture(image);
+            ResourceLocation id = mc.getTextureManager().register("rocketnautics_planet", tex);
+            tex.setFilter(true, false);
+            PLANET_TEXTURE_OBJ_LAST = new PlanetRenderInfo(id, tex);
+        }
+    }
+
+    public static void updatePlanetTexture(int powerSize, int centerX, int centerZ, byte[] mapDataPosXPosZ, byte[] mapDataPosXNegZ, byte[] mapDataNegXPosZ, byte[] mapDataNegXNegZ) {
+        PlanetRenderInfo updating = PLANET_TEXTURE_OBJ_LAST;
+        PLANET_TEXTURE_OBJ_LAST = PLANET_TEXTURE_OBJ;
+        PLANET_TEXTURE_OBJ = updating;
+        texFade = 1;
+
+        PLANET_TEXTURE_OBJ.setPowerSize(powerSize);
+        PLANET_TEXTURE_OBJ.setCenterX(centerX);
+        PLANET_TEXTURE_OBJ.setCenterZ(centerZ);
         Minecraft mc = Minecraft.getInstance();
         mc.execute(() -> {
             if (PLANET_TEXTURE_OBJ == null) return;
             
             int texSize = 1024;
             int dataSize = 256;
+            int fullDataSize = 2 * dataSize;
             NativeImage image = new NativeImage(texSize, texSize, false);
             
             for (int x = 0; x < texSize; x++) {
                 for (int y = 0; y < texSize; y++) {
-                    double u = (x / (double)texSize) * dataSize;
-                    double v = (y / (double)texSize) * dataSize;
+                    double u = (x / (double)texSize) * fullDataSize;
+                    double v = (y / (double)texSize) * fullDataSize;
                     
                     double nx = x * 0.05;
                     double ny = y * 0.05;
@@ -253,11 +297,27 @@ public class SkyHandler {
                     int sampleY = (int) Math.round(v + warpY);
                     
                     if (sampleX < 0) sampleX = 0;
-                    if (sampleX >= dataSize) sampleX = dataSize - 1;
+                    if (sampleX >= fullDataSize) sampleX = fullDataSize - 1;
                     if (sampleY < 0) sampleY = 0;
-                    if (sampleY >= dataSize) sampleY = dataSize - 1;
-                    
-                    byte colorIdx = data[sampleX + sampleY * dataSize];
+                    if (sampleY >= fullDataSize) sampleY = fullDataSize - 1;
+
+                    byte colorIdx;
+                    if (sampleX >= dataSize) {
+                        sampleX -= dataSize;
+                        if (sampleY >= dataSize) {
+                            sampleY -= dataSize;
+                            colorIdx = mapDataPosXPosZ[sampleX + sampleY * dataSize];
+                        } else {
+                            colorIdx = mapDataPosXNegZ[sampleX + sampleY * dataSize];
+                        }
+                    } else {
+                        if (sampleY >= dataSize) {
+                            sampleY -= dataSize;
+                            colorIdx = mapDataNegXPosZ[sampleX + sampleY * dataSize];
+                        } else {
+                            colorIdx = mapDataNegXNegZ[sampleX + sampleY * dataSize];
+                        }
+                    }
                     int r = 30, g = 120, b = 40;
                     switch (colorIdx) {
                         case 0: r = 10; g = 40; b = 120; break;
@@ -278,9 +338,10 @@ public class SkyHandler {
                 }
             }
             
-            PLANET_TEXTURE_OBJ.setPixels(image);
-            PLANET_TEXTURE_OBJ.upload();
-            PLANET_TEXTURE_OBJ.setFilter(false, false);
+            PLANET_TEXTURE_OBJ.getTexture().setPixels(image);
+            PLANET_TEXTURE_OBJ.getTexture().upload();
+            PLANET_TEXTURE_OBJ.getTexture().setFilter(false, false);
+            awaitUpdate = false;
         });
     }        
 

--- a/src/main/java/dev/devce/rocketnautics/content/physics/SpaceTransitionHandler.java
+++ b/src/main/java/dev/devce/rocketnautics/content/physics/SpaceTransitionHandler.java
@@ -75,7 +75,7 @@ import java.util.Optional;
 public class SpaceTransitionHandler {
     
     // Thresholds
-    private static final double OVERWORLD_SPACE_Y = 20000.0;
+    public static final double OVERWORLD_SPACE_Y = 20000.0;
     private static final double SPACE_EXIT_Y = 0.0;
     private static final double TRANSITION_SAFE_OFFSET = 50.0;
     private static final int REBUILD_DELAY_TICKS = 3;   // 0.15s — минимум для загрузки чанков
@@ -99,7 +99,7 @@ public class SpaceTransitionHandler {
     private static final String KEY_POSE_QZ = "qz";
     private static final String KEY_POSE_QW = "qw";
 
-    private static final ResourceKey<Level> SPACE_DIM = ResourceKey.create(Registries.DIMENSION, 
+    public static final ResourceKey<Level> SPACE_DIM = ResourceKey.create(Registries.DIMENSION,
         ResourceLocation.fromNamespaceAndPath(RocketNautics.MODID, "space"));
 
     private static final Path SHIPS_DIR = FMLPaths.CONFIGDIR.get().resolve("rocketnautics_ships");

--- a/src/main/java/dev/devce/rocketnautics/network/NetworkHandler.java
+++ b/src/main/java/dev/devce/rocketnautics/network/NetworkHandler.java
@@ -67,9 +67,8 @@ public class NetworkHandler {
 
     private static void handleMapRequest(net.minecraft.world.entity.player.Player rawPlayer, int powerSize) {
         if (!(rawPlayer instanceof ServerPlayer player)) return;
-        ServerLevel level = player.getServer().getLevel(net.minecraft.world.level.Level.OVERWORLD);
-        if (level == null) return;
-        
+        ServerLevel level = player.serverLevel();
+
         // Run generation async to avoid server lag
         CompletableFuture.runAsync(() -> {
             SkyDataHandler handler = SkyDataHandler.getHandlerForLevel(level);

--- a/src/main/java/dev/devce/rocketnautics/network/NetworkHandler.java
+++ b/src/main/java/dev/devce/rocketnautics/network/NetworkHandler.java
@@ -1,6 +1,7 @@
 package dev.devce.rocketnautics.network;
 
 import dev.devce.rocketnautics.RocketNautics;
+import dev.devce.rocketnautics.SkyDataHandler;
 import dev.devce.rocketnautics.client.SkyHandler;
 import net.minecraft.core.Holder;
 import net.minecraft.server.level.ServerPlayer;
@@ -27,13 +28,13 @@ public class NetworkHandler {
         registrar.playToServer(
             PlanetMapRequestPayload.TYPE,
             PlanetMapRequestPayload.CODEC,
-            (payload, context) -> context.enqueueWork(() -> handleMapRequest(context.player()))
+            (payload, context) -> context.enqueueWork(() -> handleMapRequest(context.player(), payload.powerSize()))
         );
 
         registrar.playToClient(
             PlanetMapPayload.TYPE,
             PlanetMapPayload.CODEC,
-            (payload, context) -> context.enqueueWork(() -> handleMapData(payload.mapData()))
+            (payload, context) -> context.enqueueWork(() -> handleMapData(payload.powerSize(), payload.centerX(), payload.centerZ(), payload.mapDataPosXPosZ(), payload.mapDataPosXNegZ(), payload.mapDataNegXPosZ(), payload.mapDataNegXNegZ()))
         );
 
         registrar.playToClient(
@@ -64,58 +65,25 @@ public class NetworkHandler {
         }
     }
 
-    private static void handleMapRequest(net.minecraft.world.entity.player.Player rawPlayer) {
+    private static void handleMapRequest(net.minecraft.world.entity.player.Player rawPlayer, int powerSize) {
         if (!(rawPlayer instanceof ServerPlayer player)) return;
         ServerLevel level = player.getServer().getLevel(net.minecraft.world.level.Level.OVERWORLD);
         if (level == null) return;
         
         // Run generation async to avoid server lag
         CompletableFuture.runAsync(() -> {
-            try {
-                BiomeSource source = level.getChunkSource().getGenerator().getBiomeSource();
-                Climate.Sampler sampler = level.getChunkSource().randomState().sampler();
-
-                byte[] mapData = new byte[65536]; // 256x256
-                int step = 128; // 128 blocks per pixel. Total area = 32768x32768 blocks
-                int startX = (int) player.getX() - (256 * step) / 2;
-                int startZ = (int) player.getZ() - (256 * step) / 2;
-
-                for (int x = 0; x < 256; x++) {
-                    for (int z = 0; z < 256; z++) {
-                        int worldX = startX + x * step;
-                        int worldZ = startZ + z * step;
-                        
-                        Holder<Biome> biome = source.getNoiseBiome(worldX >> 2, 64 >> 2, worldZ >> 2, sampler);
-                        byte colorIdx = 4; // Default plains/grass
-                        
-                        if (biome.is(BiomeTags.IS_OCEAN) || biome.is(BiomeTags.IS_DEEP_OCEAN)) colorIdx = 0;
-                        else if (biome.is(BiomeTags.IS_RIVER)) colorIdx = 1;
-                        else if (biome.is(BiomeTags.IS_BEACH)) colorIdx = 2;
-                        else if (biome.is(BiomeTags.HAS_DESERT_PYRAMID)) colorIdx = 3;
-                        else if (biome.is(BiomeTags.IS_FOREST)) colorIdx = 5;
-                        else if (biome.is(BiomeTags.IS_JUNGLE)) colorIdx = 6;
-                        else if (biome.is(BiomeTags.IS_TAIGA)) colorIdx = 7;
-                        else if (biome.is(BiomeTags.HAS_VILLAGE_SNOWY)) colorIdx = 8;
-                        else if (biome.is(BiomeTags.IS_BADLANDS)) colorIdx = 9;
-                        else if (biome.is(BiomeTags.IS_MOUNTAIN)) colorIdx = 10;
-                        
-                        mapData[x + z * 256] = colorIdx;
-                    }
-                }
-                
-                // Send back on main thread
-                level.getServer().execute(() -> {
-                    PacketDistributor.sendToPlayer(player, new PlanetMapPayload(mapData));
-                });
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            SkyDataHandler handler = SkyDataHandler.getHandlerForLevel(level);
+            PlanetMapPayload payload = handler.getRenderDataAtScaleAndPosition(powerSize, player.getBlockX(), player.getBlockZ());
+            // Send back on main thread
+            level.getServer().execute(() -> {
+                PacketDistributor.sendToPlayer(player, payload);
+            });
         });
     }
 
     @net.neoforged.api.distmarker.OnlyIn(net.neoforged.api.distmarker.Dist.CLIENT)
-    private static void handleMapData(byte[] data) {
-        SkyHandler.updatePlanetTexture(data);
+    private static void handleMapData(int powerSize, int centerX, int centerZ, byte[] mapDataPosXPosZ, byte[] mapDataPosXNegZ, byte[] mapDataNegXPosZ, byte[] mapDataNegXNegZ) {
+        SkyHandler.updatePlanetTexture(powerSize, centerX, centerZ, mapDataPosXPosZ, mapDataPosXNegZ, mapDataNegXPosZ, mapDataNegXNegZ);
     }
 
     @net.neoforged.api.distmarker.OnlyIn(net.neoforged.api.distmarker.Dist.CLIENT)

--- a/src/main/java/dev/devce/rocketnautics/network/PlanetMapPayload.java
+++ b/src/main/java/dev/devce/rocketnautics/network/PlanetMapPayload.java
@@ -6,15 +6,32 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 
-public record PlanetMapPayload(byte[] mapData) implements CustomPacketPayload {
+public record PlanetMapPayload(int powerSize, int centerX, int centerZ, byte[] mapDataPosXPosZ, byte[] mapDataPosXNegZ, byte[] mapDataNegXPosZ, byte[] mapDataNegXNegZ) implements CustomPacketPayload {
     public static final CustomPacketPayload.Type<PlanetMapPayload> TYPE = new CustomPacketPayload.Type<>(ResourceLocation.fromNamespaceAndPath(RocketNautics.MODID, "planet_map_data"));
     
     public static final StreamCodec<ByteBuf, PlanetMapPayload> CODEC = StreamCodec.of(
-        (buf, payload) -> buf.writeBytes(payload.mapData()),
+        (buf, payload) -> {
+            buf.writeInt(payload.powerSize());
+            buf.writeInt(payload.centerX());
+            buf.writeInt(payload.centerZ());
+            buf.writeBytes(payload.mapDataPosXPosZ());
+            buf.writeBytes(payload.mapDataPosXNegZ());
+            buf.writeBytes(payload.mapDataNegXPosZ());
+            buf.writeBytes(payload.mapDataNegXNegZ());
+        },
         buf -> {
-            byte[] data = new byte[65536]; // 256x256
-            buf.readBytes(data);
-            return new PlanetMapPayload(data);
+            int powerSize = buf.readInt();
+            int negXCorner = buf.readInt();
+            int negZCorner = buf.readInt();
+            byte[] posXPosZ = new byte[256 * 256];
+            buf.readBytes(posXPosZ);
+            byte[] posXNegZ = new byte[256 * 256];
+            buf.readBytes(posXNegZ);
+            byte[] negXPosZ = new byte[256 * 256];
+            buf.readBytes(negXPosZ);
+            byte[] negXNegZ = new byte[256 * 256];
+            buf.readBytes(negXNegZ);
+            return new PlanetMapPayload(powerSize, negXCorner, negZCorner, posXPosZ, posXNegZ, negXPosZ, negXNegZ);
         }
     );
 

--- a/src/main/java/dev/devce/rocketnautics/network/PlanetMapRequestPayload.java
+++ b/src/main/java/dev/devce/rocketnautics/network/PlanetMapRequestPayload.java
@@ -6,10 +6,13 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 
-public record PlanetMapRequestPayload() implements CustomPacketPayload {
+public record PlanetMapRequestPayload(int powerSize) implements CustomPacketPayload {
     public static final CustomPacketPayload.Type<PlanetMapRequestPayload> TYPE = new CustomPacketPayload.Type<>(ResourceLocation.fromNamespaceAndPath(RocketNautics.MODID, "planet_map_request"));
     
-    public static final StreamCodec<ByteBuf, PlanetMapRequestPayload> CODEC = StreamCodec.unit(new PlanetMapRequestPayload());
+    public static final StreamCodec<ByteBuf, PlanetMapRequestPayload> CODEC = StreamCodec.of(
+            (buf, payload) -> buf.writeInt(payload.powerSize()),
+            buf -> new PlanetMapRequestPayload(buf.readInt())
+    );
 
     @Override
     public Type<? extends CustomPacketPayload> type() {


### PR DESCRIPTION
### What Changed
Overhaul to the planet render system so that it remains an accurate reflection of the biomes below, while retaining the same resolution at all times to minimize data sent over network and prevent excessively complicated renders. Works through the transition into the space dimension.
Additionally, the resolution of the planet render has been quadrupled as a consequence of how some of the systems work.
### Why this change
An accurate depiction of what biomes are on the ground is both pretty at small scales, and helpful for players trying to find specific biomes at all scales. A place for a config setting to prevent upscaling beyond a certain point is provided, so that the "pretty" render can be kept through the entire ascent.