### PR TITLE
Quaternion <-> Euler Angles Reference Frame

### DIFF
--- a/src/main/java/dev/devce/rocketnautics/compat/computercraft/SputnikPeripheral.java
+++ b/src/main/java/dev/devce/rocketnautics/compat/computercraft/SputnikPeripheral.java
@@ -72,16 +72,16 @@ public class SputnikPeripheral implements IPeripheral {
     public final Map<String, Object> getPhysics() {
         Map<String, Object> data = new HashMap<>();
         if (sputnik.getLevel() == null) return data;
-        
+
         var subLevel = dev.ryanhcode.sable.Sable.HELPER.getContaining(sputnik.getLevel(), sputnik.getBlockPos());
         if (subLevel instanceof ServerSubLevel serverSubLevel) {
             // Mass
             data.put("mass", serverSubLevel.getMassTracker().getMass());
-            
+
             // Pose (Position & Orientation)
             var pose = serverSubLevel.logicalPose();
             var lastPose = serverSubLevel.lastPose();
-            
+
             // Orientation Quaternions
             Map<String, Double> quat = new HashMap<>();
             quat.put("w", pose.orientation().w());
@@ -89,15 +89,15 @@ public class SputnikPeripheral implements IPeripheral {
             quat.put("y", pose.orientation().y());
             quat.put("z", pose.orientation().z());
             data.put("quaternion", quat);
-            
+
             // Euler Angles (Pitch, Yaw, Roll in degrees)
-            Vector3d euler = pose.orientation().getEulerAnglesXYZ(new Vector3d());
+            Vector3d euler = pose.orientation().getEulerAnglesYXZ(new Vector3d());
             Map<String, Double> angles = new HashMap<>();
             angles.put("pitch", Math.toDegrees(euler.x));
             angles.put("yaw", Math.toDegrees(euler.y));
             angles.put("roll", Math.toDegrees(euler.z));
             data.put("euler", angles);
-            
+
             // Velocity (Calculated from position delta over 1 tick)
             Vector3d velocity = new Vector3d(pose.position()).sub(lastPose.position()).mul(20.0);
             Map<String, Double> velData = new HashMap<>();
@@ -105,12 +105,12 @@ public class SputnikPeripheral implements IPeripheral {
             velData.put("y", velocity.y);
             velData.put("z", velocity.z);
             data.put("velocity", velData);
-            
+
             // Local Gravity approximation (if needed by flight computers)
             boolean inSpace = sputnik.getLevel().dimension() == dev.devce.rocketnautics.content.physics.SpaceTransitionHandler.SPACE_DIM;
             data.put("gravity", inSpace ? 0.0 : -9.81);
         }
-        
+
         return data;
     }
 }

--- a/src/main/java/dev/devce/rocketnautics/content/blocks/SputnikBlockEntity.java
+++ b/src/main/java/dev/devce/rocketnautics/content/blocks/SputnikBlockEntity.java
@@ -29,7 +29,7 @@ public class SputnikBlockEntity extends BlockEntity {
     private boolean isForced = false;
     private ChunkPos lastForcedParentChunk = null;
     private ServerLevel lastForcedParentLevel = null;
-    
+
     private final List<IPeripheral> discoveredPeripherals = new ArrayList<>();
     private int scanCooldown = 0;
 
@@ -41,7 +41,7 @@ public class SputnikBlockEntity extends BlockEntity {
             setChanged();
         }
     };
-    
+
     // Conditions: 0 = Disabled, 1 = Altitude >, 2 = Altitude <, 3 = Velocity >, 4 = Velocity <, 5 = Time
     public final int[] stageConditions = new int[5];
     public final double[] stageValues = new double[5];
@@ -81,7 +81,7 @@ public class SputnikBlockEntity extends BlockEntity {
     private void tickNodes() {
         dev.devce.rocketnautics.content.blocks.LinkedSignalHandler.tick(level);
         graph.tick();
-        
+
         // Sync graph values to client periodically for UI display
         if (level.getGameTime() % 5 == 0) {
             level.sendBlockUpdated(worldPosition, getBlockState(), getBlockState(), 3);
@@ -93,7 +93,7 @@ public class SputnikBlockEntity extends BlockEntity {
     public void refreshPeripherals() {
         Map<UUID, IPeripheral> found = new java.util.HashMap<>();
         SubLevel sl = getSubLevel();
-        
+
         if (sl != null) {
             net.minecraft.world.level.ChunkPos min = sl.getPlot().getChunkMin();
             net.minecraft.world.level.ChunkPos max = sl.getPlot().getChunkMax();
@@ -141,8 +141,8 @@ public class SputnikBlockEntity extends BlockEntity {
     }
 
     public int getEngineCount() { return discoveredPeripherals.size(); }
-    public net.minecraft.core.BlockPos getEnginePos(int i) { 
-        return (i >= 0 && i < discoveredPeripherals.size()) ? discoveredPeripherals.get(i).getBlockPos() : null; 
+    public net.minecraft.core.BlockPos getEnginePos(int i) {
+        return (i >= 0 && i < discoveredPeripherals.size()) ? discoveredPeripherals.get(i).getBlockPos() : null;
     }
     public double getEngineThrust(int i) {
         return (i >= 0 && i < discoveredPeripherals.size()) ? discoveredPeripherals.get(i).readValue("thrust") : 0;
@@ -176,7 +176,7 @@ public class SputnikBlockEntity extends BlockEntity {
     public double getPitch() {
         SubLevel subLevel = getSubLevel();
         if (subLevel != null) {
-            Vector3d euler = subLevel.logicalPose().orientation().getEulerAnglesXYZ(new Vector3d());
+            Vector3d euler = subLevel.logicalPose().orientation().getEulerAnglesYXZ(new Vector3d());
             return Math.toDegrees(euler.x);
         }
         return 0;
@@ -189,7 +189,7 @@ public class SputnikBlockEntity extends BlockEntity {
     public double getYaw() {
         SubLevel subLevel = getSubLevel();
         if (subLevel != null) {
-            Vector3d euler = subLevel.logicalPose().orientation().getEulerAnglesXYZ(new Vector3d());
+            Vector3d euler = subLevel.logicalPose().orientation().getEulerAnglesYXZ(new Vector3d());
             return Math.toDegrees(euler.y);
         }
         return 0;
@@ -198,7 +198,7 @@ public class SputnikBlockEntity extends BlockEntity {
     public double getRoll() {
         SubLevel subLevel = getSubLevel();
         if (subLevel != null) {
-            Vector3d euler = subLevel.logicalPose().orientation().getEulerAnglesXYZ(new Vector3d());
+            Vector3d euler = subLevel.logicalPose().orientation().getEulerAnglesYXZ(new Vector3d());
             return Math.toDegrees(euler.z);
         }
         return 0;
@@ -255,12 +255,12 @@ public class SputnikBlockEntity extends BlockEntity {
             if (parent != null) {
                 Vector3d globalPos = serverSubLevel.logicalPose().position();
                 ChunkPos currentParentChunk = new ChunkPos(BlockPos.containing(globalPos.x, globalPos.y, globalPos.z));
-                
+
                 if (lastForcedParentChunk == null || !lastForcedParentChunk.equals(currentParentChunk) || lastForcedParentLevel != parent) {
                     if (lastForcedParentChunk != null && lastForcedParentLevel != null) {
                         lastForcedParentLevel.setChunkForced(lastForcedParentChunk.x, lastForcedParentChunk.z, false);
                     }
-                    
+
                     parent.setChunkForced(currentParentChunk.x, currentParentChunk.z, true);
                     lastForcedParentChunk = currentParentChunk;
                     lastForcedParentLevel = parent;
@@ -304,7 +304,7 @@ public class SputnikBlockEntity extends BlockEntity {
     public Biome getGlobalBiome() {
         if (level == null) return null;
         var subLevel = dev.ryanhcode.sable.Sable.HELPER.getContaining(level, worldPosition);
-        
+
         if (subLevel != null && !level.isClientSide) {
             Vector3d global = getGlobalPos();
             ServerLevel parent = getParentLevel((ServerSubLevel) subLevel);
@@ -312,7 +312,7 @@ public class SputnikBlockEntity extends BlockEntity {
                 return parent.getBiome(BlockPos.containing(global.x, 64, global.z)).value();
             }
         }
-        
+
         return level.getBiome(worldPosition).value();
     }
 
@@ -365,7 +365,7 @@ public class SputnikBlockEntity extends BlockEntity {
         super.saveAdditional(tag, registries);
         tag.putBoolean("Forced", isForced);
         tag.put("NodeGraph", graph.save());
-        
+
         net.minecraft.nbt.ListTag pIds = new net.minecraft.nbt.ListTag();
         for (UUID id : peripheralIds) {
             pIds.add(net.minecraft.nbt.NbtUtils.createUUID(id));
@@ -374,7 +374,7 @@ public class SputnikBlockEntity extends BlockEntity {
 
         tag.put("StageFrequencies", stageFrequencies.serializeNBT(registries));
         tag.putIntArray("StageConditions", stageConditions);
-        
+
         CompoundTag valuesTag = new CompoundTag();
         for(int i=0; i<5; i++) {
             valuesTag.putDouble("v"+i, stageValues[i]);


### PR DESCRIPTION
Due to how Minecraft's axes are laid out, the correct reference frame for Quaternion <-> Euler Angles conversion is the YXZ reference frame.

On top of this, it would also make your Euler Angle outputs compatible with CC: Advanced Math's `quaternion` API in Lua.