### PR TITLE
Prevent more than normal player drag in high pressures

### DIFF
--- a/src/main/java/dev/devce/rocketnautics/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/devce/rocketnautics/mixin/LivingEntityMixin.java
@@ -6,6 +6,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.ref.LocalDoubleRef;
 import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import dev.devce.rocketnautics.RocketConfig;
+import dev.devce.rocketnautics.RocketNautics;
 import dev.ryanhcode.sable.physics.config.dimension_physics.DimensionPhysicsData;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -28,14 +29,16 @@ public abstract class LivingEntityMixin extends Entity {
     private void rocketnautics$adjustDragByPressure(LivingEntity instance, double x, double y, double z, Operation<Void> original, @Local(ordinal = 1) Vec3 vec35, @Local(ordinal = 1) float f3, @Local(ordinal = 1) double d2) {
         int limit = RocketConfig.SERVER.entitySpeedLimit.get();
         // note that delta movement is in m/t not m/s, so we multiply our speed squared by a correction factor of 400 (20 * 20)
-        if (400 * (x * x + y * y + z * z) > limit * limit) {
-            original.call(instance, x, y, z);
-            return;
+        if (400 * (x * x + y * y + z * z) <= limit * limit) {
+            double pressure = DimensionPhysicsData.getAirPressure(level(), new Vector3d(instance.getX(), instance.getY(), instance.getZ()));
+            if (pressure < 1) {
+                double drag1 = 1 - (1 - f3) * pressure;
+                double drag2 = 1 - 0.02 * pressure;
+                original.call(instance, vec35.x * drag1, this instanceof FlyingAnimal ? d2 * drag1 : d2 * drag2, vec35.z * drag1);
+                return;
+            }
         }
-        double pressure = DimensionPhysicsData.getAirPressure(level(), new Vector3d(instance.getX(), instance.getY(), instance.getZ()));
-        double drag1 = 1 - (1 - f3) * pressure;
-        double drag2 = 1 - 0.02 * pressure;
-        original.call(instance, vec35.x * drag1, this instanceof FlyingAnimal ? d2 * drag1 : d2 * drag2, vec35.z * drag1);
+        original.call(instance, x, y, z);
     }
 
 }


### PR DESCRIPTION
### What Changed
Prevents our code that modifies entity drag based on air pressure from ever increasing entity drag, allowing it only to decrease entity drag.
### Why this change
Aeronautics defines low altitudes in the overworld, nether, and end to be higher than normal pressure. This makes our drag modification very noticeable and restrictive to player movement, especially on worlds that are inherently low like superflat.