### PR TITLE
fix: shade and relocate luaj-jse to resolve module split-package conf…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,13 @@
 plugins {
     id 'net.neoforged.moddev' version '1.0.1'
+    id 'io.github.goooler.shadow' version '8.1.8'
 }
 
 configurations {
     luajRuntime
+    shade
     implementation.extendsFrom(luajRuntime)
+    implementation.extendsFrom(shade)
 }
 
 repositories {
@@ -116,7 +119,24 @@ dependencies {
     runtimeOnly("cc.tweaked:cc-tweaked-${minecraft_version}-forge:${cc_version}")
 
     luajRuntime("org.luaj:luaj-jse:3.0.1")
-    jarJar("org.luaj:luaj-jse:3.0.1")
+    shade("org.luaj:luaj-jse:3.0.1")
+}
+
+jar {
+    archiveClassifier.set('dev')
+}
+
+shadowJar {
+    archiveClassifier.set('')
+    configurations = [project.configurations.shade]
+    relocate 'org.luaj', 'dev.devce.rocketnautics.shaded.luaj'
+    mergeServiceFiles()
+}
+
+tasks.named('jar') { finalizedBy shadowJar }
+
+artifacts {
+    archives shadowJar
 }
 
 sourceSets.main.resources { srcDir 'src/generated/resources' }


### PR DESCRIPTION
…lict

Mods bundling a different LuaJ variant (e.g. Fragmentum's luaj-core-figura) cause a Java 21 module resolution crash:

  ResolutionException: Modules luaj.core.figura and luaj.jse export
  package org.luaj.vm2.lib to module ejml.core

Replace jarJar(luaj-jse) with the goooler Shadow plugin, which relocates org.luaj into dev.devce.rocketnautics.shaded.luaj and embeds it directly in the mod jar. This eliminates the nested luaj-jse module entirely.

Fixes compatibility with: Fragmentum 2.1.1+