### PR TITLE
Tweak entity drag reduction

### DIFF
--- a/src/main/java/dev/devce/rocketnautics/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/devce/rocketnautics/mixin/LivingEntityMixin.java
@@ -7,6 +7,7 @@ import com.llamalad7.mixinextras.sugar.ref.LocalDoubleRef;
 import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import dev.devce.rocketnautics.RocketConfig;
 import dev.devce.rocketnautics.RocketNautics;
+import dev.devce.rocketnautics.content.physics.GlobalSpacePhysicsHandler;
 import dev.ryanhcode.sable.physics.config.dimension_physics.DimensionPhysicsData;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -29,8 +30,8 @@ public abstract class LivingEntityMixin extends Entity {
     private void rocketnautics$adjustDragByPressure(LivingEntity instance, double x, double y, double z, Operation<Void> original, @Local(ordinal = 1) Vec3 vec35, @Local(ordinal = 1) float f3, @Local(ordinal = 1) double d2) {
         int limit = RocketConfig.SERVER.entitySpeedLimit.get();
         // note that delta movement is in m/t not m/s, so we multiply our speed squared by a correction factor of 400 (20 * 20)
-        if (400 * (x * x + y * y + z * z) <= limit * limit) {
-            double pressure = DimensionPhysicsData.getAirPressure(level(), new Vector3d(instance.getX(), instance.getY(), instance.getZ()));
+        if (!instance.onGround() && 400 * (x * x + y * y + z * z) <= limit * limit) {
+            double pressure = 1 - GlobalSpacePhysicsHandler.calculateGravityFactor(level(), instance.getY());
             if (pressure < 1) {
                 double drag1 = 1 - (1 - f3) * pressure;
                 double drag2 = 1 - 0.02 * pressure;


### PR DESCRIPTION
### What Changed
Entity drag reduction is now tied to gravity reduction instead of pressure.
Entity drag reduction now only applies when the entity is not grounded.
### Why this change
We cannot rely on air pressure curves being defined for modded dimensions, but the default state of gravity is completely on. It also kicks in too soon for most people.
Having drag reduction apply to grounded entities was never desirable behavior, as space does not turn everything into ice, but simply does not have the atmosphere slow you down.