### PR TITLE
Change applicable access transformers to mixin accessors

### DIFF
--- a/src/main/java/dev/devce/rocketnautics/client/render/HologramTableRenderer.java
+++ b/src/main/java/dev/devce/rocketnautics/client/render/HologramTableRenderer.java
@@ -11,6 +11,7 @@ import dev.devce.rocketnautics.content.orbit.DeepSpaceData;
 import dev.devce.rocketnautics.content.orbit.universe.CubePlanet;
 import dev.devce.rocketnautics.content.orbit.universe.DeepSpacePosition;
 import dev.devce.rocketnautics.content.orbit.universe.UniverseDefinition;
+import dev.devce.rocketnautics.mixin.GameRendererAccessor;
 import dev.ryanhcode.sable.Sable;
 import dev.ryanhcode.sable.sublevel.ClientSubLevel;
 import it.unimi.dsi.fastutil.Pair;
@@ -90,7 +91,7 @@ public class HologramTableRenderer extends SafeBlockEntityRenderer<HologramTable
         Frame largestFrame = pair.left();
         if (position != null) {
             int steps = RocketConfig.CLIENT.orbitPredictionSteps.getAsInt();
-            double fov = minecraft.gameRenderer.getFov(camera, partialTicks, true);
+            double fov = ((GameRendererAccessor)minecraft.gameRenderer).rocketnautics$getFov(camera, partialTicks, true);
             float s = (float) (0.01 * Math.sqrt(holoSize) * Math.tan(Math.toRadians(fov) / 2));
             DebugRenderer.renderFilledBox(ms, bufferSource, -s, -s, -s, s, s, s, 0.0f, 1.0f, 0.8f, 0.8f);
             renderVelocityVector(position.getCurrentOrbit().getPVCoordinates(renderDate, largestFrame).getVelocity(), bufferSource, ms, camera);

--- a/src/main/java/dev/devce/rocketnautics/content/items/JetpackItem.java
+++ b/src/main/java/dev/devce/rocketnautics/content/items/JetpackItem.java
@@ -8,6 +8,7 @@ import dev.devce.rocketnautics.RocketConfig;
 import dev.devce.rocketnautics.api.capability.IBacktank;
 import dev.devce.rocketnautics.api.capability.JetpackFluidHandlerItemStack;
 import dev.devce.rocketnautics.content.physics.GlobalSpacePhysicsHandler;
+import dev.devce.rocketnautics.mixin.BucketItemAccessor;
 import dev.devce.rocketnautics.mixin.LivingEntityAccessor;
 import dev.devce.rocketnautics.registry.RocketDataComponents;
 import dev.devce.rocketnautics.registry.RocketItems;
@@ -231,7 +232,7 @@ public class JetpackItem extends ArmorItem implements IBacktank {
                     ourCap.fill(drained, IFluidHandler.FluidAction.EXECUTE);
                     carriedSlotAccess.set(otherCap.getContainer());
                     if (other.getItem() instanceof BucketItem b) {
-                        b.playEmptySound(player, player.level(), player.blockPosition());
+                        ((BucketItemAccessor) b).rocketnautics$playEmptySound(player, player.level(), player.blockPosition());
                     }
                     return true;
                 }

--- a/src/main/java/dev/devce/rocketnautics/content/physics/SpaceTransitionHandler.java
+++ b/src/main/java/dev/devce/rocketnautics/content/physics/SpaceTransitionHandler.java
@@ -10,6 +10,7 @@ import dev.devce.rocketnautics.api.orbit.DeepSpaceHelper;
 import dev.devce.rocketnautics.content.orbit.DeepSpaceData;
 import dev.devce.rocketnautics.content.orbit.DeepSpaceInstance;
 import dev.devce.rocketnautics.content.orbit.universe.CubePlanet;
+import dev.devce.rocketnautics.mixin.DistanceManagerAccessor;
 import dev.devce.rocketnautics.network.DebugLogPayload;
 import dev.devce.rocketnautics.network.SeamlessTransitionPayload;
 import dev.egg.SubLevelWarper;
@@ -217,7 +218,7 @@ public class SpaceTransitionHandler {
                     deepSpace.getChunkSource().chunkMap.getDistanceManager().addRegionTicket(TicketType.UNKNOWN, cPos, 1, cPos);
                     map.updateChunkStatus(cPos, true);
                 });
-                deepSpace.getChunkSource().chunkMap.getDistanceManager().tickingTicketsTracker.runAllUpdates();
+                ((DistanceManagerAccessor) deepSpace.getChunkSource().chunkMap.getDistanceManager()).rocketnautics$tickingTicketsTracker().runAllUpdates();
                 map.processChanges();
                 exitLoadedFromDeepSpace(instance, deepSpace, rot, destLevel, destPos, seen);
                 part.forEach(cPos -> {

--- a/src/main/java/dev/devce/rocketnautics/mixin/BucketItemAccessor.java
+++ b/src/main/java/dev/devce/rocketnautics/mixin/BucketItemAccessor.java
@@ -1,0 +1,16 @@
+package dev.devce.rocketnautics.mixin;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.BucketItem;
+import net.minecraft.world.level.LevelAccessor;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import javax.annotation.Nullable;
+
+@Mixin(BucketItem.class)
+public interface BucketItemAccessor {
+    @Invoker("playEmptySound")
+    void rocketnautics$playEmptySound(@Nullable Player p_40696_, LevelAccessor p_40697_, BlockPos p_40698_);
+}

--- a/src/main/java/dev/devce/rocketnautics/mixin/DistanceManagerAccessor.java
+++ b/src/main/java/dev/devce/rocketnautics/mixin/DistanceManagerAccessor.java
@@ -1,0 +1,12 @@
+package dev.devce.rocketnautics.mixin;
+
+import net.minecraft.server.level.DistanceManager;
+import net.minecraft.server.level.TickingTracker;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(DistanceManager.class)
+public interface DistanceManagerAccessor {
+    @Accessor("tickingTicketsTracker")
+    TickingTracker rocketnautics$tickingTicketsTracker();
+}

--- a/src/main/java/dev/devce/rocketnautics/mixin/GameRendererAccessor.java
+++ b/src/main/java/dev/devce/rocketnautics/mixin/GameRendererAccessor.java
@@ -1,0 +1,12 @@
+package dev.devce.rocketnautics.mixin;
+
+import net.minecraft.client.Camera;
+import net.minecraft.client.renderer.GameRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(GameRenderer.class)
+public interface GameRendererAccessor {
+    @Invoker("getFov")
+    double rocketnautics$getFov(Camera p_109142_, float p_109143_, boolean p_109144_);
+}

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,5 +1,1 @@
 public-f net.minecraft.data.recipes.RecipeProvider getName()Ljava/lang/String;
-public net.minecraft.client.renderer.GameRenderer getFov(Lnet.minecraft.client.Camera;FZ)D
-public net.minecraft.server.level.DistanceManager tickingTicketsTracker
-public net.minecraft.world.item.BucketItem playEmptySound(Lnet.minecraft.world.entity.player.Player;Lnet.minecraft.world.level.LevelAccessor;Lnet.minecraft.core.BlockPos;)V
-public net.minecraft.world.item.MobBucketItem playEmptySound(Lnet.minecraft.world.entity.player.Player;Lnet.minecraft.world.level.LevelAccessor;Lnet.minecraft.core.BlockPos;)V

--- a/src/main/resources/rocketnautics.mixins.json
+++ b/src/main/resources/rocketnautics.mixins.json
@@ -5,6 +5,8 @@
   "compatibilityLevel": "JAVA_21",
   "mixins": [
     "BacktankUtilMixin",
+    "BucketItemAccessor",
+    "DistanceManagerAccessor",
     "DivingHelmetItemMixin",
     "EntityMixin",
     "LivingEntityAccessor",
@@ -16,6 +18,7 @@
   "client": [
     "ClientLevelMixin",
     "ClientPacketListenerMixin",
+    "GameRendererAccessor",
     "LevelRendererMixin",
     "MinecraftMixin"
   ],


### PR DESCRIPTION
### What Changed
Moves our access transformers that are not being used to change finality into mixin accessors
### Why this change
In the latest release, for some people and some mod configurations, our access transformers are causing a cascading failure across all access transformers. This change hopefully prevents that.