### PR TITLE
Wiki for data-driven universe

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -1,0 +1,21 @@
+name: Publish wiki
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'wiki/**'
+      - '.github/workflows/publish-wiki.yml'
+
+concurrency:
+  group: publish-wiki
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  publish-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: Andrew-Chen-Wang/github-wiki-action@v5

--- a/src/main/java/dev/devce/rocketnautics/content/orbit/universe/builder/SerializablePosition.java
+++ b/src/main/java/dev/devce/rocketnautics/content/orbit/universe/builder/SerializablePosition.java
@@ -90,7 +90,7 @@ public interface SerializablePosition {
 
     record FullOrbitPosition(AbsoluteDate coordinateDate, Vector3D position, Vector3D velocity) implements SerializablePosition {
         public static final MapCodec<FullOrbitPosition> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
-                DeepSpaceHelper.DATE_CODEC.fieldOf("coordinate_date").forGetter(FullOrbitPosition::coordinateDate),
+                DeepSpaceHelper.DATE_CODEC.optionalFieldOf("coordinate_date", DeepSpaceHelper.EPOCH).forGetter(FullOrbitPosition::coordinateDate),
                 DeepSpaceHelper.VEC3D_CODEC.fieldOf("position").forGetter(FullOrbitPosition::position),
                 DeepSpaceHelper.VEC3D_CODEC.fieldOf("velocity").forGetter(FullOrbitPosition::velocity)
         ).apply(instance, FullOrbitPosition::new));
@@ -137,7 +137,7 @@ public interface SerializablePosition {
 
     record CircularOrbitPosition(AbsoluteDate coordinateDate, Vector3D position, Vector3D orbitAxis) implements SerializablePosition {
         public static final MapCodec<CircularOrbitPosition> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
-                DeepSpaceHelper.DATE_CODEC.fieldOf("coordinate_date").forGetter(CircularOrbitPosition::coordinateDate),
+                DeepSpaceHelper.DATE_CODEC.optionalFieldOf("coordinate_date", DeepSpaceHelper.EPOCH).forGetter(CircularOrbitPosition::coordinateDate),
                 DeepSpaceHelper.VEC3D_CODEC.fieldOf("position").forGetter(CircularOrbitPosition::position),
                 DeepSpaceHelper.VEC3D_CODEC.fieldOf("orbit_axis").forGetter(CircularOrbitPosition::orbitAxis)
         ).apply(instance, CircularOrbitPosition::new));
@@ -187,7 +187,7 @@ public interface SerializablePosition {
 
     record CircularOrbitPeriod(AbsoluteDate coordinateDate, Optional<Vector3D> positionDirection, Vector3D orbitAxis, double periodSeconds) implements SerializablePosition {
         public static final MapCodec<CircularOrbitPeriod> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
-                DeepSpaceHelper.DATE_CODEC.fieldOf("coordinate_date").forGetter(CircularOrbitPeriod::coordinateDate),
+                DeepSpaceHelper.DATE_CODEC.optionalFieldOf("coordinate_date", DeepSpaceHelper.EPOCH).forGetter(CircularOrbitPeriod::coordinateDate),
                 DeepSpaceHelper.VEC3D_CODEC.optionalFieldOf("position_direction").forGetter(CircularOrbitPeriod::positionDirection),
                 DeepSpaceHelper.VEC3D_CODEC.fieldOf("orbit_axis").forGetter(CircularOrbitPeriod::orbitAxis),
                 Codec.DOUBLE.fieldOf("period_seconds").forGetter(CircularOrbitPeriod::periodSeconds)

--- a/src/main/java/dev/devce/rocketnautics/content/orbit/universe/builder/SerializableRotation.java
+++ b/src/main/java/dev/devce/rocketnautics/content/orbit/universe/builder/SerializableRotation.java
@@ -50,7 +50,7 @@ public interface SerializableRotation {
         public static final MapCodec<Velocity> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
                 DeepSpaceHelper.DATE_CODEC.optionalFieldOf("starting_date", DeepSpaceHelper.EPOCH).forGetter(Velocity::startingDate),
                 DeepSpaceHelper.ROTATION_CODEC.optionalFieldOf("starting_rotation", Rotation.IDENTITY).forGetter(Velocity::startingRotation),
-                DeepSpaceHelper.VEC3D_CODEC.fieldOf("position").forGetter(Velocity::velocity)
+                DeepSpaceHelper.VEC3D_CODEC.fieldOf("velocity").forGetter(Velocity::velocity)
         ).apply(instance, Velocity::new));
 
         public static Velocity of(Vector3D velocity) {

--- a/wiki/Celestial Positions.md
+++ b/wiki/Celestial Positions.md
@@ -1,0 +1,43 @@
+Celestial positions are the primary way that locations are defined in the universe. They are by default relative to the parent body of whatever object is using the celestial position.
+
+### Fixed
+A fixed position.
+
+**`type`** (required): `fixed`
+
+**`position`** (required): The [Vector3D](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Common-Types#Vector3D) offset from the parent.
+
+### Full Orbit
+A fully configurable orbit that can be elliptical but tends to be inconvenient to work with.
+
+**`type`** (required): `full_orbit`
+
+**`coordinate_date`** (optional): The [AbsoluteDate](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Common-Types#AbsoluteDate) of the celestial position.
+
+**`position`** (required): The [Vector3D](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Common-Types#Vector3D) position of the celestial position at `coordinate_date`.
+
+**`velocity`** (required): The [Vector3D](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Common-Types#Vector3D) velocity of the celestial position at `coordinate_date`.
+
+### Circular Orbit -- Position
+A circular orbit defined by a position.
+
+**`type`** (required): `circular_orbit_position`
+
+**`coordinate_date`** (optional): The [AbsoluteDate](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Common-Types#AbsoluteDate) of the celestial position.
+
+**`position`** (required): The [Vector3D](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Common-Types#Vector3D) position of the celestial position at `coordinate_date`.
+
+**`orbit_axis`** (required): The [Vector3D](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Common-Types#Vector3D) axis the orbit rotates around. Negate this vector to negate the velocity.
+
+### Circular Orbit -- Period
+A circular orbit defined by a period.
+
+**`type`** (required): `circular_orbit_period`
+
+**`coordinate_date`** (optional): The [AbsoluteDate](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Common-Types#AbsoluteDate) of the celestial position.
+
+**`position_direction`** (optional, defaults to an arbitrary vector): The [Vector3D](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Common-Types#Vector3D) direction that the celestial position should be in at `coordinate_date`. Magnitude is ignored.
+
+**`orbit_axis`** (required): The [Vector3D](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Common-Types#Vector3D) axis the orbit rotates around. Negate this vector to negate the velocity.
+
+**`period_seconds`** (required): The number of seconds it takes for the celestial position to complete an orbit around the parent.

--- a/wiki/Celestial Rotations.md
+++ b/wiki/Celestial Rotations.md
@@ -1,0 +1,38 @@
+Celestial rotations are the primary way that orientations are defined in the universe.
+
+### Velocity
+A rotation defined by an angular velocity.
+
+**`type`** (required): `velocity`
+
+**`starting_date`** (optional): The [AbsoluteDate](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Common-Types#AbsoluteDate) of the celestial rotation.
+
+**`starting_rotation`** (optional): The [Rotation](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Common-Types#Rotation) of the celestial rotation at `starting_date`.
+
+**`velocity`** (required): The [Vector3D](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Common-Types#Vector3D) angular velocity in rad/s of the celestial rotation.
+
+### Period
+A rotation defined by the period.
+
+**`type`** (required): `period`
+
+**`starting_date`** (optional): The [AbsoluteDate](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Common-Types#AbsoluteDate) of the celestial rotation.
+
+**`starting_rotation`** (optional): The [Rotation](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Common-Types#Rotation) of the celestial rotation at `starting_date`.
+
+**`rotation_axis`** (required): The [Vector3D](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Common-Types#Vector3D) axis of the celestial rotation.
+
+**`period_seconds`** (required): The number of seconds it takes for the celestial rotation to complete a rotation.
+
+### Spin-Orbit Resonance
+A rotation defined by resonance with the orbit period.
+
+**`type`** (required): `tidal_lock`
+
+**`starting_date`** (optional): The [AbsoluteDate](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Common-Types#AbsoluteDate) of the celestial rotation.
+
+**`starting_rotation`** (optional): The [Rotation](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Common-Types#Rotation) of the celestial rotation at `starting_date`.
+
+**`rotation_axis`** (optional, defaults to the orbit axis): The [Vector3D](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Common-Types#Vector3D) axis of the celestial rotation.
+
+**`rotations_per_orbit`** (required): The number of rotations completed every orbit. Can be less than one.

--- a/wiki/Common Types.md
+++ b/wiki/Common Types.md
@@ -1,0 +1,18 @@
+### Vector3D
+**`x`** (required): The x position. Floating point.
+
+**`y`** (required): The y position. Floating point.
+
+**`z`** (required): The z position. Floating point.
+### AbsoluteDate
+**`sec`** (required): The number of seconds since time zero. Must be an integer.
+
+**`atto`** (required): The number of attoseconds since time zero. Must be an integer.
+### Rotation
+**`q0`** (required): The scalar coordinate of the quaternion. Floating point.
+
+**`q1`** (required): The first coordinate of the vectorial part of the quaternion. Floating point.
+
+**`q2`** (required): The second coordinate of the vectorial part of the quaternion. Floating point.
+
+**`q3`** (required): The third coordinate of the vectorial part of the quaternion. Floating point.

--- a/wiki/Cube Planets.md
+++ b/wiki/Cube Planets.md
@@ -1,0 +1,53 @@
+Cube planets are the most straightforward celestial body. They are loaded from `/data/<namespace>/universe_planets/<name>.json`.
+
+Cube planets are constructed in a "priority override" system, where the non-empty fields of higher priority files override the fields of lower priority files. As such, all fields are by default optional and only present fields will override the settings of lower priority files. However, the planet will fail to construct and an error will be logged if critical information is missing after the composition is finished. Note that celestial positions and rotations cannot be partially overridden, but must be swapped out completely.
+
+Certain fields are "paired" with other fields. This means that at least one of the paired fields must be present, but some will override others if present. As an example, either `mu` or `acceleration_at_surface` must be provided, but `mu` will take priority over `acceleration_at_surface`.
+
+While Cube Planets can be linked to custom dimensions, we do not provide any tools to add dimensions. However, datapacks are entirely capable of adding custom dimensions, and tutorials exist for this.
+
+### Fields
+
+**`parent`** (critical): The name of the parent body. If the planet has no parent body, such as `sol` by default, use `root` here.
+
+**`name`** (required): The name field is extremely important. In the vast majority of cases it will be the same as the file name. The name field is used to determine what files stack on each other during the "priority override" phase.
+
+**`radius`** (critical): The radius of the cube planet, equivalent to half its side length.
+
+**`mu`** (critical, paired with `acceleration_at_surface`) the standard gravitational parameter (μ) of this cube planet.
+
+**`acceleration_at_surface`** (critical, paired with `mu`) the acceleration that physics objects are subject to at a distance of `radius` from the center of the cube planet.
+
+**`position`** (critical) A [Celestial Position](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Celestial-Positions)
+
+**`rotation`** (critical) A [Celestial Rotation](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Celestial-Rotations)
+
+**`dimension_data`** (optional) A compound object consisting of the following fields:
+
+> **`linked_dimension`** (critical) The resource location of the dimension linked to this cube planet.
+>
+> **`allowed_transfer`** (optional, default `none`) Which transitions between deep space and the dimension are allowed. Options are `all`, `none`, `to_space`, and `to_dimension`.
+> 
+> **`dimension_transfer_height`** (optional, default `20_000`) The height of the transition point. Applies to both deep space and the dimension. Must be an integer.
+> 
+> **`render_universe_in_dimension`** (optional, default `false`) Whether the universe should render in the dimension's skybox. The dimension's default skybox must be manually disabled elsewhere.
+> 
+> **`dimension_day_time_controller_name`** (optional) The name of the celestial body that will be compared against to determine the time of day in the linked dimension. Recommended if the universe is rendered in the dimension.
+> 
+> **`apply_gravity_correction_to_entities_in_dimension`** (optional, default `false`) Whether a gravity correction should be applied to entities in the dimension. Normal gravity is assumed to be `11m/s^2` at surface because this is the Sable default, and the correction will be proportional to the ratio between this and the cube planet's acceleration at surface. The acceleration at surface can be derived from `mu`.
+
+**`planet_extras`** (optional) A compound object consisting of the following fields:
+
+> **`is_star`** (optional, default `false`) Whether the cube planet is a star and should have a star render.
+> 
+> **`has_clouds`** (optional, default `false`) Whether the cube planet should have clouds render above its surface.
+> 
+> **`light_source_name`** (optional) The name of the celestial body that will be used to determine shadows cast across the planet's surface.
+
+**`texture_override`** (optional) A resource location to a texture to use instead of generating the texture from biome data. Changing how the texture is generated from biome data is not yet supported.
+
+**`use_texture_override`** (optional, default `true`) Whether the `texture_override` should actually be used, if it is present.
+
+**`priority`** (optional, default `1000`) The priority of this file in the "priority override" phase. Must be an integer. Cube planets added by the base mod have a priority of 0.
+
+**`disabled`** (optional, default `false`) Whether this planet should be loaded. Useful for disabling planets added by the base mod.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,5 @@
+## Adding your own universe with Cosmonautics
+The Cosmonautics universe is loaded dynamically from JSON files at runtime, allowing it to be modified using datapacks instead of through an addon mod. Familiarity with datapacks is recommended. Introductory guides to datapacks are commonly available across the internet.
+
+The pages below detail how to customize the universe components currently supported by Cosmonautics:
+- [Cube Planets](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Cube-Planets)


### PR DESCRIPTION
### What changed
Adds markdown files for a github wiki, and adds content relevant to modifying the universe .json files
### Why this change
How to modify the universe files is more suited for a github wiki than an ingame ponder. Additionally, using a publish action allows the wiki to be modified in sync with PRs that change how the universe is loaded.