### PR TITLE
Misc Improvements 2

### DIFF
--- a/src/generated/resources/data/rocketnautics/universe_planets/gas_giant.json
+++ b/src/generated/resources/data/rocketnautics/universe_planets/gas_giant.json
@@ -7,10 +7,6 @@
   },
   "position": {
     "type": "circular_orbit_period",
-    "coordinate_date": {
-      "atto": 0,
-      "sec": 0
-    },
     "orbit_axis": {
       "x": 0.0,
       "y": 1.0,

--- a/src/generated/resources/data/rocketnautics/universe_planets/ice_world.json
+++ b/src/generated/resources/data/rocketnautics/universe_planets/ice_world.json
@@ -7,10 +7,6 @@
   },
   "position": {
     "type": "circular_orbit_period",
-    "coordinate_date": {
-      "atto": 0,
-      "sec": 0
-    },
     "orbit_axis": {
       "x": 0.0,
       "y": 1.0,

--- a/src/generated/resources/data/rocketnautics/universe_planets/mars.json
+++ b/src/generated/resources/data/rocketnautics/universe_planets/mars.json
@@ -7,10 +7,6 @@
   },
   "position": {
     "type": "circular_orbit_period",
-    "coordinate_date": {
-      "atto": 0,
-      "sec": 0
-    },
     "orbit_axis": {
       "x": 0.0,
       "y": 1.0,

--- a/src/generated/resources/data/rocketnautics/universe_planets/moon.json
+++ b/src/generated/resources/data/rocketnautics/universe_planets/moon.json
@@ -15,10 +15,6 @@
   },
   "position": {
     "type": "circular_orbit_period",
-    "coordinate_date": {
-      "atto": 0,
-      "sec": 0
-    },
     "orbit_axis": {
       "x": 0.0,
       "y": 1.0,
@@ -30,12 +26,6 @@
   "radius": 750000.0,
   "rotation": {
     "type": "tidal_lock",
-    "rotations_per_orbit": 1.0,
-    "starting_rotation": {
-      "q0": 0.7071067811865476,
-      "q1": 0.0,
-      "q2": -0.7071067811865475,
-      "q3": 0.0
-    }
+    "rotations_per_orbit": -1.0
   }
 }

--- a/src/generated/resources/data/rocketnautics/universe_planets/moon.json
+++ b/src/generated/resources/data/rocketnautics/universe_planets/moon.json
@@ -4,8 +4,26 @@
   "dimension_data": {
     "allowed_transfer": "all",
     "apply_gravity_correction_to_entities_in_dimension": true,
+    "atmosphere_composition": {
+      "21000": [
+        "low_density",
+        "drowning"
+      ]
+    },
     "dimension_day_time_controller_name": "sol",
     "dimension_transfer_height": 20000,
+    "entity_drag_multiplier": [
+      {
+        "altitude": 4000.0,
+        "slope": 0.0,
+        "value": 1.0
+      },
+      {
+        "altitude": 7000.0,
+        "slope": -6.0E-4,
+        "value": 0.0
+      }
+    ],
     "linked_dimension": "rocketnautics:moon",
     "render_universe_in_dimension": true
   },

--- a/src/generated/resources/data/rocketnautics/universe_planets/overworld.json
+++ b/src/generated/resources/data/rocketnautics/universe_planets/overworld.json
@@ -13,10 +13,6 @@
   },
   "position": {
     "type": "circular_orbit_period",
-    "coordinate_date": {
-      "atto": 0,
-      "sec": 0
-    },
     "orbit_axis": {
       "x": 0.0,
       "y": 1.0,

--- a/src/generated/resources/data/rocketnautics/universe_planets/overworld.json
+++ b/src/generated/resources/data/rocketnautics/universe_planets/overworld.json
@@ -3,7 +3,26 @@
   "acceleration_at_surface": 11.0,
   "dimension_data": {
     "allowed_transfer": "all",
+    "atmosphere_composition": {
+      "21000": [
+        "low_density",
+        "drowning"
+      ],
+      "5000": []
+    },
     "dimension_transfer_height": 20000,
+    "entity_drag_multiplier": [
+      {
+        "altitude": 4000.0,
+        "slope": 0.0,
+        "value": 1.0
+      },
+      {
+        "altitude": 7000.0,
+        "slope": -6.0E-4,
+        "value": 0.0
+      }
+    ],
     "linked_dimension": "minecraft:overworld"
   },
   "name": "overworld",

--- a/src/main/java/dev/devce/rocketnautics/api/capability/JetpackFluidHandlerItemStack.java
+++ b/src/main/java/dev/devce/rocketnautics/api/capability/JetpackFluidHandlerItemStack.java
@@ -48,4 +48,35 @@ public class JetpackFluidHandlerItemStack extends FluidHandlerItemStack {
     public boolean canFillFluidType(FluidStack fluid) {
         return isFluidValid(0, fluid);
     }
+
+    @Override
+    public int fill(FluidStack resource, FluidAction doFill) {
+        if (container.getCount() != 1 || resource.isEmpty() || !canFillFluidType(resource)) {
+            return 0;
+        }
+
+        FluidStack contained = getFluid();
+        if (contained.isEmpty()) {
+            int fillAmount = Math.min(getTankCapacity(0), resource.getAmount());
+
+            if (doFill.execute()) {
+                setFluid(resource.copyWithAmount(fillAmount));
+            }
+
+            return fillAmount;
+        } else {
+            if (FluidStack.isSameFluidSameComponents(contained, resource)) {
+                int fillAmount = Math.min(getTankCapacity(0) - contained.getAmount(), resource.getAmount());
+
+                if (doFill.execute() && fillAmount > 0) {
+                    contained.grow(fillAmount);
+                    setFluid(contained);
+                }
+
+                return fillAmount;
+            }
+
+            return 0;
+        }
+    }
 }

--- a/src/main/java/dev/devce/rocketnautics/api/orbit/AllowedTransfer.java
+++ b/src/main/java/dev/devce/rocketnautics/api/orbit/AllowedTransfer.java
@@ -1,0 +1,26 @@
+package dev.devce.rocketnautics.api.orbit;
+
+import com.mojang.serialization.Codec;
+import dev.devce.rocketnautics.content.orbit.universe.PlanetDimensionData;
+import net.minecraft.util.StringRepresentable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Locale;
+
+public enum AllowedTransfer implements StringRepresentable {
+    ALL, NONE, TO_SPACE, TO_DIMENSION;
+    public static final Codec<AllowedTransfer> CODEC = StringRepresentable.fromEnum(AllowedTransfer::values);
+
+    public boolean allowToSpace() {
+        return this == ALL || this == TO_SPACE;
+    }
+
+    public boolean allowToDimension() {
+        return this == ALL || this == TO_DIMENSION;
+    }
+
+    @Override
+    public @NotNull String getSerializedName() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/dev/devce/rocketnautics/api/orbit/AtmosphereFlags.java
+++ b/src/main/java/dev/devce/rocketnautics/api/orbit/AtmosphereFlags.java
@@ -1,0 +1,22 @@
+package dev.devce.rocketnautics.api.orbit;
+
+import com.mojang.serialization.Codec;
+import net.minecraft.util.StringRepresentable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.EnumSet;
+import java.util.Locale;
+
+public enum AtmosphereFlags implements StringRepresentable {
+    LOW_DENSITY, DROWNING;
+    public static final Codec<AtmosphereFlags> CODEC = StringRepresentable.fromEnum(AtmosphereFlags::values);
+
+    public static EnumSet<AtmosphereFlags> empty() {
+        return EnumSet.noneOf(AtmosphereFlags.class);
+    }
+
+    @Override
+    public @NotNull String getSerializedName() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/dev/devce/rocketnautics/api/orbit/FrameTree.java
+++ b/src/main/java/dev/devce/rocketnautics/api/orbit/FrameTree.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 /**
  * Holder for carefully defined frames that can be sent across network to the client.
@@ -172,6 +173,18 @@ public final class FrameTree {
 
     public @NotNull Frame getOrekitFrame() {
         return orekitFrame;
+    }
+
+    public void ifOrbit(Consumer<KeplerianOrbit> consumer) {
+        if (type == Type.KEPLERIAN_ORBIT) {
+            consumer.accept(orbit);
+        }
+    }
+
+    public void ifFixed(Consumer<Vector3D> consumer) {
+        if (type == Type.FIXED) {
+            consumer.accept(position);
+        }
     }
 
     public String getName() {

--- a/src/main/java/dev/devce/rocketnautics/client/DeepSpaceHandler.java
+++ b/src/main/java/dev/devce/rocketnautics/client/DeepSpaceHandler.java
@@ -7,6 +7,7 @@ import com.mojang.datafixers.util.Either;
 import dev.devce.rocketnautics.RocketConfig;
 import dev.devce.rocketnautics.RocketNautics;
 import dev.devce.rocketnautics.api.orbit.DeepSpaceHelper;
+import dev.devce.rocketnautics.content.orbit.DeepSpaceData;
 import dev.devce.rocketnautics.content.orbit.universe.CubePlanet;
 import dev.devce.rocketnautics.content.orbit.universe.DeepSpacePosition;
 import dev.devce.rocketnautics.content.orbit.universe.UniverseDefinition;
@@ -23,13 +24,17 @@ import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderStateShard;
 import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.debug.DebugRenderer;
 import net.minecraft.client.renderer.texture.SimpleTexture;
+import net.minecraft.core.Direction;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.ArrayListDeque;
+import net.minecraft.util.Mth;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.VoxelShape;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -54,7 +59,10 @@ public final class DeepSpaceHandler {
 
     private static @Nullable UniverseDefinition UNIVERSE;
     private static final Int2ObjectAVLTreeMap<IntObjectPair<PreparedTexture>> KNOWN_RENDER_DATA = new Int2ObjectAVLTreeMap<>();
-    
+
+    private static final ResourceLocation FORCEFIELD_LOCATION = ResourceLocation.withDefaultNamespace("textures/misc/forcefield.png");
+    private static final float FORCEFIELD_DIST = 8;
+
     private static long receivedUniverseDateTick = -1;
     private static AbsoluteDate receivedUniverseDate;
     private static float receivedUniverseTickrate;
@@ -208,11 +216,125 @@ public final class DeepSpaceHandler {
         PoseStack poseStack = event.getPoseStack();
         poseStack.pushPose();
         poseStack.mulPose(event.getModelViewMatrix());
-        float partial = event.getPartialTick().getGameTimeDeltaPartialTick(true);
-        AbsoluteDate currentDate = getRenderDate(partial);
-        renderUniverse(null, poseStack, null, event.getPartialTick().getGameTimeDeltaTicks(),
-                partial, currentDate, receivedPosition.getPosition(currentDate), receivedPosition.getFrame(), event.getCamera());
+        Vec3 position = event.getCamera().getPosition();
+        VoxelShape box = DeepSpaceData.getBoxForPosition(position);
+        if (box.bounds().contains(position)) {
+            float partial = event.getPartialTick().getGameTimeDeltaPartialTick(true);
+            AbsoluteDate currentDate = getRenderDate(partial);
+            renderUniverse(null, poseStack, null, event.getPartialTick().getGameTimeDeltaTicks(),
+                    partial, currentDate, receivedPosition.getPosition(currentDate), receivedPosition.getFrame(), event.getCamera());
+        }
+        renderInstanceBox(poseStack, position);
         poseStack.popPose();
+    }
+
+    private static boolean renderInstanceBox(PoseStack poseStack, Vec3 position) {
+        VoxelShape box = DeepSpaceData.getBoxForPosition(position);
+        RenderSystem.enableBlend();
+        RenderSystem.enableDepthTest();
+        RenderSystem.blendFuncSeparate(
+                GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO
+        );
+        RenderSystem.setShaderTexture(0, FORCEFIELD_LOCATION);
+        RenderSystem.depthMask(Minecraft.useShaderTransparency());
+        RenderSystem.setShader(GameRenderer::getPositionTexShader);
+        RenderSystem.polygonOffset(-3.0F, -3.0F);
+        RenderSystem.enablePolygonOffset();
+        RenderSystem.disableCull();
+        float maxX = (float) box.max(Direction.Axis.X);
+        float minX = (float) box.min(Direction.Axis.X);
+        float maxY = (float) box.max(Direction.Axis.Y);
+        float minY = (float) box.min(Direction.Axis.Y);
+        float maxZ = (float) box.max(Direction.Axis.Z);
+        float minZ = (float) box.min(Direction.Axis.Z);
+        float s = (float) Math.min(Minecraft.getInstance().gameRenderer.getDepthFar(), box.bounds().getXsize());
+        float s2 = s / 2;
+        float clampedX = (float) Mth.clamp(position.x(), minX + s2, maxX - s2);
+        float properX = (float) (clampedX - position.x());
+        float clampedY = (float) Mth.clamp(position.y(), minY + s2, maxY - s2);
+        float properY = (float) (clampedY - position.y());
+        float clampedZ = (float) Mth.clamp(position.z(), minZ + s2, maxZ - s2);
+        float properZ = (float) (clampedZ - position.z());
+
+        if (position.x() > maxX - FORCEFIELD_DIST) {
+            BufferBuilder bufferbuilder = Tesselator.getInstance().begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
+            float d = (float) (maxX - position.x());
+            double frac = Math.min(1, 1 - d / FORCEFIELD_DIST);
+            RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, (float) frac);
+
+            bufferbuilder.addVertex(poseStack.last(), d, properY + s2, properZ - s2).setUv(0 + clampedZ, 0 - clampedY);
+            bufferbuilder.addVertex(poseStack.last(), d, properY + s2, properZ + s2).setUv(s + clampedZ, 0 - clampedY);
+            bufferbuilder.addVertex(poseStack.last(), d, properY - s2, properZ + s2).setUv(s + clampedZ, s - clampedY);
+            bufferbuilder.addVertex(poseStack.last(), d, properY - s2, properZ - s2).setUv(0 + clampedZ, s - clampedY);
+            BufferUploader.drawWithShader(bufferbuilder.buildOrThrow());
+        }
+        if (position.x() < minX + FORCEFIELD_DIST) {
+            BufferBuilder bufferbuilder = Tesselator.getInstance().begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
+            float d = (float) (minX - position.x());
+            double frac = Math.min(1, 1 + d / FORCEFIELD_DIST);
+            RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, (float) frac);
+
+            bufferbuilder.addVertex(poseStack.last(), d, properY + s2, properZ - s2).setUv(0 + clampedZ, 0 - clampedY);
+            bufferbuilder.addVertex(poseStack.last(), d, properY + s2, properZ + s2).setUv(s + clampedZ, 0 - clampedY);
+            bufferbuilder.addVertex(poseStack.last(), d, properY - s2, properZ + s2).setUv(s + clampedZ, s - clampedY);
+            bufferbuilder.addVertex(poseStack.last(), d, properY - s2, properZ - s2).setUv(0 + clampedZ, s - clampedY);
+            BufferUploader.drawWithShader(bufferbuilder.buildOrThrow());
+        }
+        if (position.y() > maxY - FORCEFIELD_DIST) {
+            BufferBuilder bufferbuilder = Tesselator.getInstance().begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
+            float d = (float) (maxY - position.y());
+            double frac = Math.min(1, 1 - d / FORCEFIELD_DIST);
+            RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, (float) frac);
+
+            bufferbuilder.addVertex(poseStack.last(), properX + s2, d, properZ - s2).setUv(0 + clampedZ, 0 - clampedX);
+            bufferbuilder.addVertex(poseStack.last(), properX + s2, d, properZ + s2).setUv(s + clampedZ, 0 - clampedX);
+            bufferbuilder.addVertex(poseStack.last(), properX - s2, d, properZ + s2).setUv(s + clampedZ, s - clampedX);
+            bufferbuilder.addVertex(poseStack.last(), properX - s2, d, properZ - s2).setUv(0 + clampedZ, s - clampedX);
+            BufferUploader.drawWithShader(bufferbuilder.buildOrThrow());
+        }
+        if (position.y() < minY + FORCEFIELD_DIST) {
+            BufferBuilder bufferbuilder = Tesselator.getInstance().begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
+            float d = (float) (minY - position.y());
+            double frac = Math.min(1, 1 + d / FORCEFIELD_DIST);
+            RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, (float) frac);
+
+            bufferbuilder.addVertex(poseStack.last(), properX + s2, d, properZ - s2).setUv(0 + clampedZ, 0 - clampedX);
+            bufferbuilder.addVertex(poseStack.last(), properX + s2, d, properZ + s2).setUv(s + clampedZ, 0 - clampedX);
+            bufferbuilder.addVertex(poseStack.last(), properX - s2, d, properZ + s2).setUv(s + clampedZ, s - clampedX);
+            bufferbuilder.addVertex(poseStack.last(), properX - s2, d, properZ - s2).setUv(0 + clampedZ, s - clampedX);
+            BufferUploader.drawWithShader(bufferbuilder.buildOrThrow());
+        }
+        if (position.z() > maxZ - FORCEFIELD_DIST) {
+            BufferBuilder bufferbuilder = Tesselator.getInstance().begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
+            float d = (float) (maxZ - position.z());
+            double frac = Math.min(1, 1 - (maxZ - position.z()) / FORCEFIELD_DIST);
+            RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, (float) frac);
+
+            bufferbuilder.addVertex(poseStack.last(), properX - s2, properY + s2, d).setUv(0 + clampedX, 0 - clampedY);
+            bufferbuilder.addVertex(poseStack.last(), properX + s2, properY + s2, d).setUv(s + clampedX, 0 - clampedY);
+            bufferbuilder.addVertex(poseStack.last(), properX + s2, properY - s2, d).setUv(s + clampedX, s - clampedY);
+            bufferbuilder.addVertex(poseStack.last(), properX - s2, properY - s2, d).setUv(0 + clampedX, s - clampedY);
+            BufferUploader.drawWithShader(bufferbuilder.buildOrThrow());
+        }
+        if (position.z() < minZ + FORCEFIELD_DIST) {
+            BufferBuilder bufferbuilder = Tesselator.getInstance().begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
+            float d = (float) (minZ - position.z());
+            double frac = Math.min(1, 1 + d / FORCEFIELD_DIST);
+            RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, (float) frac);
+
+            bufferbuilder.addVertex(poseStack.last(), properX - s2, properY + s2, d).setUv(0 + clampedX, 0 - clampedY);
+            bufferbuilder.addVertex(poseStack.last(), properX + s2, properY + s2, d).setUv(s + clampedX, 0 - clampedY);
+            bufferbuilder.addVertex(poseStack.last(), properX + s2, properY - s2, d).setUv(s + clampedX, s - clampedY);
+            bufferbuilder.addVertex(poseStack.last(), properX - s2, properY - s2, d).setUv(0 + clampedX, s - clampedY);
+            BufferUploader.drawWithShader(bufferbuilder.buildOrThrow());
+        }
+
+        RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+        RenderSystem.polygonOffset(0.0F, 0.0F);
+        RenderSystem.disablePolygonOffset();
+        RenderSystem.enableCull();
+        RenderSystem.depthMask(true);
+        return false;
     }
 
     private static void renderUniverse(@Nullable CubePlanet exclude, PoseStack poseStack, @Nullable Quaternionf rotation, float deltaTick, float partialTick, AbsoluteDate renderDate, Vector3D pos, Frame posFrame, Camera camera) {
@@ -591,7 +713,7 @@ public final class DeepSpaceHandler {
                 .setLightmapState(RenderStateShard.NO_LIGHTMAP)
                 .createCompositeState(false);
         return RenderType.create("rocketnautics_hologram", DefaultVertexFormat.POSITION_TEX_COLOR,
-                VertexFormat.Mode.QUADS, 256, true, true, rendertype$state);
+                VertexFormat.Mode.QUADS, 256, false, true, rendertype$state);
     }
 
 

--- a/src/main/java/dev/devce/rocketnautics/client/render/HologramTableRenderer.java
+++ b/src/main/java/dev/devce/rocketnautics/client/render/HologramTableRenderer.java
@@ -15,6 +15,7 @@ import dev.ryanhcode.sable.Sable;
 import dev.ryanhcode.sable.companion.math.JOMLConversion;
 import dev.ryanhcode.sable.sublevel.ClientSubLevel;
 import it.unimi.dsi.fastutil.Pair;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -29,8 +30,10 @@ import org.hipparchus.geometry.euclidean.threed.Vector3D;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Matrix4f;
 import org.joml.Vector3d;
+import org.joml.Vector3f;
 import org.jspecify.annotations.NonNull;
 import org.orekit.frames.Frame;
+import org.orekit.orbits.KeplerianOrbit;
 import org.orekit.orbits.Orbit;
 import org.orekit.time.AbsoluteDate;
 import org.orekit.utils.PVCoordinates;
@@ -91,63 +94,89 @@ public class HologramTableRenderer extends SafeBlockEntityRenderer<HologramTable
         double fov = ((GameRendererAccessor)minecraft.gameRenderer).rocketnautics$getFov(camera, partialTicks, true);
         float s = (float) (0.01 * Math.sqrt(holoSize) * Math.tan(Math.toRadians(fov) / 2));
         DebugRenderer.renderFilledBox(ms, bufferSource, -s, -s, -s, s, s, s, 0.0f, 1.0f, 0.8f, 0.8f);
+        double scaleFactor = holoSize / holoScale;
+        if (position != null) {
+            renderVelocityVector(position.getCurrentOrbit().getPVCoordinates(renderDate, largestFrame).getVelocity(), bufferSource, ms, camera);
+        }
+        ms.pushPose();
+        Vector3D scaledPos = centerFrame.getStaticTransformTo(largestFrame, renderDate).transformPosition(posInFrame).scalarMultiply(scaleFactor);
+        ms.translate(-scaledPos.getX(), -scaledPos.getY(), -scaledPos.getZ());
+        int count = 0;
+        Predicate<Vector3D> distancePred = v -> 4 * v.distanceSq(scaledPos) > holoSize * holoSize;
+        // TODO make the speed and size of the cycle configurable
+        float[] cycle = new float[] { ((renderTicks + partialTicks) * getCycleSpeed()) % getCycleLength(), ((renderTicks + partialTicks) * getCycleSpeed() * 4) % (getCycleLength() * 4), ((renderTicks + partialTicks) * getCycleSpeed() * 16) % (getCycleLength() * 16) };
         if (position != null) {
             int steps = RocketConfig.CLIENT.orbitPredictionSteps.getAsInt();
-            renderVelocityVector(position.getCurrentOrbit().getPVCoordinates(renderDate, largestFrame).getVelocity(), bufferSource, ms, camera);
 //            ms.pushPose();
 //            ms.translate(camera.getPosition().x, camera.getPosition().y, camera.getPosition().z);
 //            DebugRenderer.renderFloatingText(ms, bufferSource, String.format("Speed: %.2e", velocity.getNorm()), 0, -sPos * 5, 0, FastColor.ARGB32.color(255, 255, 255, 255));
 //            DebugRenderer.renderFloatingText(ms, bufferSource, String.format("Velocity: %.2e, %.2e, %.2e", velocity.getX(), velocity.getY(), velocity.getZ()), 0, -sPos * 10, 0, FastColor.ARGB32.color(255, 255, 255, 255));
 //            ms.popPose();
             if (steps > 0) {
-                // TODO make the speed and size of the cycle configurable
-                float cycle = (((renderTicks + partialTicks) * getCycleSpeed()) % getCycleLength());
-                float cycle2 = (((renderTicks + partialTicks) * getCycleSpeed()) % (getCycleLength() * 5));
-                ms.pushPose();
-                double scaleFactor = holoSize / holoScale;
-                Vector3D scaledPos = centerFrame.getStaticTransformTo(largestFrame, renderDate).transformPosition(posInFrame).scalarMultiply(scaleFactor);
-                ms.translate(-scaledPos.getX(), -scaledPos.getY(), -scaledPos.getZ());
                 // render our orbit prediction
                 Iterator<Vector3D> iter = DeepSpaceHandler.getPositionPrediction(largestFrame, steps);
-                Predicate<Vector3D> distancePred = v -> 4 * v.distanceSq(scaledPos) > holoSize * holoSize;
-                int count = renderChainedPositions(iter, scaleFactor, bufferSource, ms, distancePred, cycle, cycle2, s, 0.3f);
-                // render planetary orbit predictions
-                for (CubePlanet planet : pair.right()) {
-                    if (planet.orekitFrame() == largestFrame) continue;
-                    ms.pushPose();
-                    PVCoordinates c = planet.getPVCoordinates(renderDate, largestFrame);
-                    ms.translate(c.getPosition().getX() * scaleFactor, c.getPosition().getY() * scaleFactor, c.getPosition().getZ() * scaleFactor);
-
-//                    Vector3D ct1 = new Vector3D(0, 0.3, 0);
-//                    Rotation rotation = planet.getRotationAtTime(renderDate);
-//                    rotation = rotation.compose(new Rotation(Vector3D.PLUS_J, Vector3D.PLUS_K), RotationConvention.VECTOR_OPERATOR);
-//                    ct1 = rotation.applyTo(ct1);
-//                    Vector3D ct2 = planet.rotationDescription().getRotationRate().scalarMultiply(100);
-//                    DebugRenderer.renderFilledBox(ms, bufferSource, ct1.getX() - s, ct1.getY() - s, ct1.getZ() - s, ct2.getX() + s, ct2.getY() + s, ct2.getZ() + s, 1, 1, 1, 1);
-//
-//                    if (planet.orekitFrame() == largestFrame) {
-//                        ms.popPose();
-//                        continue;
-//                    }
-                    renderVelocityVector(c.getVelocity(), bufferSource, ms, camera);
-                    ms.popPose();
-                    iter = DeepSpaceHandler.getPredictionDates(count)
-                            .map(d -> planet.getPosition(d, largestFrame))
-                            .iterator();
-                    renderChainedPositions(iter, scaleFactor, bufferSource, ms, distancePred, cycle, cycle2, s, 1.0f);
-                }
+                count = renderChainedPositions(iter, scaleFactor, bufferSource, ms, distancePred, cycle, s, 0.3f, false);
                 renderIntersects(bufferSource, ms, largestFrame, pair.right(), scaleFactor, s);
+            }
+        }
+        // render planetary orbits
+        for (CubePlanet planet : pair.right()) {
+            // only do orbit predictions for celestial bodies orbiting the dominant object
+            if (planet.orekitFrame() == largestFrame || planet.orekitFrame().getParent() != largestFrame) continue;
+            // orbit lines
+            planet.frame().ifOrbit(o -> renderPlanetOrbit(bufferSource, ms, scaleFactor, o, distancePred));
+            if (count > 0) {
+                // velocity
+                ms.pushPose();
+                PVCoordinates c = planet.getPVCoordinates(renderDate, largestFrame);
+                ms.translate(c.getPosition().getX() * scaleFactor, c.getPosition().getY() * scaleFactor, c.getPosition().getZ() * scaleFactor);
+                renderVelocityVector(c.getVelocity(), bufferSource, ms, camera);
                 ms.popPose();
+                // red dots
+                var iter = DeepSpaceHandler.getPredictionDates(count)
+                        .map(d -> planet.getPosition(d, largestFrame))
+                        .iterator();
+                renderChainedPositions(iter, scaleFactor, bufferSource, ms, distancePred, cycle, s, 1, true);
             }
         }
         ms.popPose();
         ms.popPose();
+        ms.popPose();
+    }
+
+    private void renderPlanetOrbit(MultiBufferSource bufferSource, PoseStack ms, double scaleFactor, KeplerianOrbit orbit, Predicate<Vector3D> skipCondition) {
+        double period = orbit.getKeplerianPeriod();
+        if (Double.isInfinite(period)) return;
+        VertexConsumer buffer = bufferSource.getBuffer(RenderType.lineStrip());
+        recurseRenderPlanetOrbit(buffer, ms, scaleFactor, orbit, orbit.getDate(), period, skipCondition);
+        PVCoordinates coords = orbit.getPVCoordinates(orbit.getDate(), orbit.getFrame());
+        Vector3f norm = DeepSpaceHelper.adaptf(coords.getVelocity()).normalize();
+        buffer.addVertex(ms.last(), DeepSpaceHelper.adaptf(coords.getPosition()).mul((float) scaleFactor))
+                .setColor(0.8f, 0.8f, 1f, skipCondition.test(coords.getPosition().scalarMultiply(scaleFactor)) ? 0f : 0.8f)
+                .setNormal(ms.last(), norm.x(), norm.y(), norm.z());
+    }
+
+    private void recurseRenderPlanetOrbit(VertexConsumer buffer, PoseStack ms, double scaleFactor, KeplerianOrbit orbit, AbsoluteDate point, double len, Predicate<Vector3D> skipCondition) {
+        double threshold = Math.PI / 32;
+        PVCoordinates coords = orbit.getPVCoordinates(point, orbit.getFrame());
+        // alternative approach -- acceleration norm divided by velocity norm
+        double angularVelocity = coords.getAngularVelocity().getNorm();
+        if (angularVelocity * len > threshold) {
+            recurseRenderPlanetOrbit(buffer, ms, scaleFactor, orbit, point, len / 2, skipCondition);
+            recurseRenderPlanetOrbit(buffer, ms, scaleFactor, orbit, point.shiftedBy(len / 2), len / 2, skipCondition);
+        } else {
+            Vector3f norm = DeepSpaceHelper.adaptf(coords.getVelocity()).normalize();
+            buffer.addVertex(ms.last(), DeepSpaceHelper.adaptf(coords.getPosition()).mul((float) scaleFactor))
+                    .setColor(0.8f, 0.8f, 1f, skipCondition.test(coords.getPosition().scalarMultiply(scaleFactor)) ? 0f : 0.8f)
+                    .setNormal(ms.last(), norm.x(), norm.y(), norm.z());
+        }
     }
 
     private void renderVelocityVector(Vector3D velocity, MultiBufferSource bufferSource, PoseStack ms, Camera camera) {
         VertexConsumer bufVel = bufferSource.getBuffer(RenderType.lineStrip());
         Vector3D normed = velocity.normalize();
-        Vector3D pointer = new Vector3D(0.8, normed, 0.2, normed.crossProduct(DeepSpaceHelper.adaptf(camera.getLookVector())).normalize());
+        Vector3D cross = normed.crossProduct(DeepSpaceHelper.adaptf(camera.getLookVector())).normalize();
+        Vector3D pointer = new Vector3D(0.8, normed, -0.1, cross);
         Vector3D normal = pointer.subtract(normed).normalize();
         bufVel.addVertex(ms.last(), 0f, 0f, 0f)
                 .setColor(1.0f, 0f, 1.0f, 0.8f)
@@ -158,12 +187,23 @@ public class HologramTableRenderer extends SafeBlockEntityRenderer<HologramTable
         bufVel.addVertex(ms.last(), (float) pointer.getX(), (float) pointer.getY(), (float) pointer.getZ())
                 .setColor(1.0f, 0f, 1.0f, 0.8f)
                 .setNormal(ms.last(), (float) normal.getX(), (float) normal.getY(), (float) normal.getZ());
+        pointer = new Vector3D(0.8, normed, 0.1, cross);
+        normal = pointer.subtract(normed).normalize();
+        bufVel.addVertex(ms.last(), (float) pointer.getX(), (float) pointer.getY(), (float) pointer.getZ())
+                .setColor(1.0f, 0f, 1.0f, 0.8f)
+                .setNormal(ms.last(), (float) cross.getX(), (float) cross.getY(), (float) cross.getZ());
+        bufVel.addVertex(ms.last(), (float) normed.getX(), (float) normed.getY(), (float) normed.getZ())
+                .setColor(1.0f, 0f, 1.0f, 0.8f)
+                .setNormal(ms.last(), (float) normal.getX(), (float) normal.getY(), (float) normal.getZ());
     }
 
-    private int renderChainedPositions(Iterator<Vector3D> iter, double scaleFactor, MultiBufferSource bufferSource, PoseStack ms, Predicate<Vector3D> stopCondition, float cycle, float cycle2, double s, float b) {
+    private int renderChainedPositions(Iterator<Vector3D> iter, double scaleFactor, MultiBufferSource bufferSource, PoseStack ms, Predicate<Vector3D> stopCondition, float[] cycle, double s, float b, boolean onlyCycle) {
+        if (onlyCycle && !doCycle()) return 0;
         VertexConsumer buffer = bufferSource.getBuffer(RenderType.lineStrip());
-        List<Vector3D> cycling = new ArrayList<>();
-        List<Vector3D> cycling2 = new ArrayList<>();
+        List<List<Vector3D>> cycling = new ArrayList<>(cycle.length);
+        for (int i = 0; i < cycle.length; i++) {
+            cycling.add(new ObjectArrayList<>());
+        }
         int count = 0;
         if (iter.hasNext()) {
             Vector3D v = iter.next().scalarMultiply(scaleFactor);
@@ -173,15 +213,16 @@ public class HologramTableRenderer extends SafeBlockEntityRenderer<HologramTable
                 if (stopCondition.test(v)) {
                     break;
                 }
-                if (doCycle() && count == Math.ceil(cycle)) {
-                    float partialCycle = cycle % 1;
-                    cycling.add(new Vector3D(partialCycle, vNext, 1 - partialCycle, v));
-                }
-                if (doCycle() && cycle != cycle2 && count == Math.ceil(cycle2)) {
-                    float partialCycle = cycle2 % 1;
-                    cycling2.add(new Vector3D(partialCycle, vNext, 1 - partialCycle, v));
+                if (doCycle()) {
+                    for (int i = 0; i < cycle.length; i++) {
+                        if (count == Math.ceil(cycle[i])) {
+                            float partialCycle = cycle[i] % 1;
+                            cycling.get(i).add(new Vector3D(partialCycle, vNext, 1 - partialCycle, v));
+                        }
+                    }
                 }
                 count++;
+                if (!onlyCycle) {
                 Vector3D dif = vNext.subtract(v);
                 if (dif.getNormSq() > 1e-20) {
                     norm = dif.normalize();
@@ -192,21 +233,20 @@ public class HologramTableRenderer extends SafeBlockEntityRenderer<HologramTable
                 buffer.addVertex(ms.last(), (float) v.getX(), (float) v.getY(), (float) v.getZ())
                         .setColor(0.8f, 0.8f, b, 0.8f)
                         .setNormal(ms.last(), (float) norm.getX(), (float) norm.getY(), (float) norm.getZ());
+                }
                 v = vNext;
             }
         }
         if (doCycle()) {
-            for (Vector3D c : cycling) {
-                ms.pushPose();
-                ms.translate(c.getX(), c.getY(), c.getZ());
-                DebugRenderer.renderFilledBox(ms, bufferSource, -s, -s, -s, s, s, s, 1.0f, 0f, 0.2f, 1.0f);
-                ms.popPose();
-            }
-            for (Vector3D c : cycling2) {
-                ms.pushPose();
-                ms.translate(c.getX(), c.getY(), c.getZ());
-                DebugRenderer.renderFilledBox(ms, bufferSource, -s, -s, -s, s, s, s, 0.7f, 0f, 0.1f, 1.0f);
-                ms.popPose();
+            for (int i = 0; i < cycling.size(); i++) {
+                List<Vector3D> points = cycling.get(i);
+                float factor = 1 - 0.3f * i / cycle.length;
+                for (Vector3D c : points) {
+                    ms.pushPose();
+                    ms.translate(c.getX(), c.getY(), c.getZ());
+                    DebugRenderer.renderFilledBox(ms, bufferSource, -s, -s, -s, s, s, s, factor, factor, b, 1.0f);
+                    ms.popPose();
+                }
             }
         }
         return count;

--- a/src/main/java/dev/devce/rocketnautics/client/render/HologramTableRenderer.java
+++ b/src/main/java/dev/devce/rocketnautics/client/render/HologramTableRenderer.java
@@ -12,6 +12,7 @@ import dev.devce.rocketnautics.content.orbit.universe.DeepSpacePosition;
 import dev.devce.rocketnautics.content.orbit.universe.UniverseDefinition;
 import dev.devce.rocketnautics.mixin.GameRendererAccessor;
 import dev.ryanhcode.sable.Sable;
+import dev.ryanhcode.sable.companion.math.JOMLConversion;
 import dev.ryanhcode.sable.sublevel.ClientSubLevel;
 import it.unimi.dsi.fastutil.Pair;
 import net.minecraft.client.Camera;
@@ -27,6 +28,7 @@ import net.neoforged.api.distmarker.OnlyIn;
 import org.hipparchus.geometry.euclidean.threed.Vector3D;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Matrix4f;
+import org.joml.Vector3d;
 import org.jspecify.annotations.NonNull;
 import org.orekit.frames.Frame;
 import org.orekit.orbits.Orbit;
@@ -57,17 +59,22 @@ public class HologramTableRenderer extends SafeBlockEntityRenderer<HologramTable
             position = DeepSpaceHandler.getReceivedPosition();
             renderDate = DeepSpaceHandler.getRenderDate(partialTicks);
         } else {
-            renderDate = DeepSpaceHelper.getDateByTicks(renderTicks).shiftedBy(partialTicks / 20);
+            renderDate = DeepSpaceHandler.getPredictedUniverseDate(partialTicks);
+            if (renderDate == null) {
+                renderDate = DeepSpaceHelper.EPOCH;
+            }
         }
         Frame centerFrame;
+        Vector3D posInFrame;
         if (position != null) {
             centerFrame = position.getFrame();
+            posInFrame = position.getPosition(renderDate);
         } else {
             CubePlanet inhabiting = universe.getPlanetByDimension(be.getLevel().dimension());
             if (inhabiting == null) return;
             centerFrame = inhabiting.orekitFrame();
+            posInFrame = DeepSpaceHelper.localPositionToGlobalPositionAndRotation(JOMLConversion.atCenterOf(be.getBlockPos(), new Vector3d()), null, inhabiting, renderDate).first().getPosition();
         }
-        Vector3D posInFrame = position != null ? position.getPosition(renderDate) : Vector3D.ZERO;
         ms.pushPose();
         ms.translate(0.5, holoSize / 2d + 1, 0.5);
         ms.pushPose();
@@ -81,11 +88,11 @@ public class HologramTableRenderer extends SafeBlockEntityRenderer<HologramTable
         // finish hologram rendering
         Pair<Frame, List<CubePlanet>> pair = DeepSpaceHandler.renderHologram(posInFrame, centerFrame, universe, renderDate, holoScale / holoSize, holoScale / 2, ms, bufferSource);
         Frame largestFrame = pair.left();
+        double fov = ((GameRendererAccessor)minecraft.gameRenderer).rocketnautics$getFov(camera, partialTicks, true);
+        float s = (float) (0.01 * Math.sqrt(holoSize) * Math.tan(Math.toRadians(fov) / 2));
+        DebugRenderer.renderFilledBox(ms, bufferSource, -s, -s, -s, s, s, s, 0.0f, 1.0f, 0.8f, 0.8f);
         if (position != null) {
             int steps = RocketConfig.CLIENT.orbitPredictionSteps.getAsInt();
-            double fov = ((GameRendererAccessor)minecraft.gameRenderer).rocketnautics$getFov(camera, partialTicks, true);
-            float s = (float) (0.01 * Math.sqrt(holoSize) * Math.tan(Math.toRadians(fov) / 2));
-            DebugRenderer.renderFilledBox(ms, bufferSource, -s, -s, -s, s, s, s, 0.0f, 1.0f, 0.8f, 0.8f);
             renderVelocityVector(position.getCurrentOrbit().getPVCoordinates(renderDate, largestFrame).getVelocity(), bufferSource, ms, camera);
 //            ms.pushPose();
 //            ms.translate(camera.getPosition().x, camera.getPosition().y, camera.getPosition().z);

--- a/src/main/java/dev/devce/rocketnautics/content/items/LegThrustersItem.java
+++ b/src/main/java/dev/devce/rocketnautics/content/items/LegThrustersItem.java
@@ -5,22 +5,19 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import com.simibubi.create.content.equipment.armor.BacktankUtil;
 import com.simibubi.create.content.equipment.armor.BaseArmorItem;
-import com.simibubi.create.content.equipment.armor.DivingHelmetItem;
-import com.simibubi.create.foundation.advancement.AllAdvancements;
 import dev.devce.rocketnautics.RocketConfig;
 import dev.devce.rocketnautics.RocketNautics;
+import dev.devce.rocketnautics.api.orbit.AtmosphereFlags;
 import dev.devce.rocketnautics.content.physics.GlobalSpacePhysicsHandler;
 import dev.devce.rocketnautics.registry.RocketDataComponents;
 import dev.ryanhcode.sable.Sable;
 import dev.ryanhcode.sable.api.sublevel.SubLevelContainer;
-import dev.ryanhcode.sable.mixinterface.entity.entities_stick_sublevels.EntityStickExtension;
 import dev.ryanhcode.sable.mixinterface.entity.entity_sublevel_collision.EntityMovementExtension;
 import dev.ryanhcode.sable.mixinterface.entity.entity_sublevel_collision.LivingEntityMovementExtension;
 import dev.ryanhcode.sable.sublevel.SubLevel;
 import net.createmod.catnip.nbt.NBTHelper;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.Holder;
-import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket;
 import net.minecraft.resources.ResourceLocation;
@@ -128,7 +125,7 @@ public class LegThrustersItem extends BaseArmorItem {
         }
 
         boolean inFluid = !entity.isEyeInFluidType(NeoForgeMod.EMPTY_TYPE.value());
-        boolean inSpace = !GlobalSpacePhysicsHandler.canBreathe(entity);
+        boolean inSpace = GlobalSpacePhysicsHandler.getFlags(entity).contains(AtmosphereFlags.LOW_DENSITY);
 
         int period = inSpace ? 4 : inFluid ? 2 : 1;
 

--- a/src/main/java/dev/devce/rocketnautics/content/items/LegThrustersItem.java
+++ b/src/main/java/dev/devce/rocketnautics/content/items/LegThrustersItem.java
@@ -147,9 +147,7 @@ public class LegThrustersItem extends BaseArmorItem {
         SubLevelContainer c = relativeID != null ? SubLevelContainer.getContainer(entity.level()) : null;
         SubLevel relative = c != null ? c.getSubLevel(relativeID) : null;
         if (relative != null && ((EntityMovementExtension) entity).sable$getTrackingSubLevel() != relative) {
-            Vector3d extra = ((LivingEntityMovementExtension) entity).sable$getInheritedVelocity();
-            Vector3f change = relative.logicalPose().position().sub(relative.lastPose().position(), new Vector3d()).sub(extra).get(new Vector3f());
-            entity.setPos(entity.position().add(new Vec3(change)));
+            ((LivingEntityMovementExtension) entity).sable$getInheritedVelocity().set(relative.logicalPose().position().sub(relative.lastPose().position(), new Vector3d()));
         }
         entity.setDeltaMovement(entity.getDeltaMovement().scale(0.9));
         return true;

--- a/src/main/java/dev/devce/rocketnautics/content/orbit/DeepSpaceData.java
+++ b/src/main/java/dev/devce/rocketnautics/content/orbit/DeepSpaceData.java
@@ -178,22 +178,26 @@ public class DeepSpaceData extends SavedData {
     // TODO mixin to CollisionGetter#borderCollision and Entity#collectColliders to add this
     // collision box at the same place the world border's collision box is added.
     public static VoxelShape getColliderForPosition(Vec3 position) {
+        // subtract the instance bounds from the infinity box
+        return Shapes.join(
+                Shapes.INFINITY,
+                getBoxForPosition(position),
+                BooleanOp.ONLY_FIRST
+        );
+    }
+
+    public static VoxelShape getBoxForPosition(Vec3 position) {
         // compute the instance we are in
         int[] sizeAndId = getChunkPowerSizeIdWithinSizeForParameters((int) position.x, (int) position.z);
         ChunkPos corner = getMinCornerForParameters(sizeAndId[0], sizeAndId[1]);
         int blockSize = 16 * (2 << sizeAndId[0]);
-        // subtract the instance bounds from the infinity box
-        return Shapes.join(
-                Shapes.INFINITY,
-                Shapes.box(
-                        corner.getMinBlockX(),
-                        LOGICAL_INSTANCE_HEIGHT,
-                        corner.getMinBlockZ(),
-                        corner.getMinBlockX() + blockSize + 1,
-                        LOGICAL_INSTANCE_HEIGHT + blockSize + 1,
-                        corner.getMinBlockZ() + blockSize + 1
-                ),
-                BooleanOp.ONLY_FIRST
+        return Shapes.box(
+                corner.getMinBlockX(),
+                LOGICAL_INSTANCE_HEIGHT,
+                corner.getMinBlockZ(),
+                corner.getMinBlockX() + blockSize + 1,
+                LOGICAL_INSTANCE_HEIGHT + blockSize + 1,
+                corner.getMinBlockZ() + blockSize + 1
         );
     }
 

--- a/src/main/java/dev/devce/rocketnautics/content/orbit/DeepSpaceData.java
+++ b/src/main/java/dev/devce/rocketnautics/content/orbit/DeepSpaceData.java
@@ -212,7 +212,7 @@ public class DeepSpaceData extends SavedData {
             size = chunkPowerSize * 16 + (2 << chunkPowerSize);
         }
         // derive id from Z position and chunk size
-        return new int[] { chunkPowerSize, negZ / (16 + size) };
+        return new int[] { chunkPowerSize, negZ / (16 + size - chunkPowerSize * 16) };
     }
 
     public static ChunkPos getMinCornerForParameters(int chunkPowerSize, int idWithinSize) {

--- a/src/main/java/dev/devce/rocketnautics/content/orbit/DeepSpaceInstance.java
+++ b/src/main/java/dev/devce/rocketnautics/content/orbit/DeepSpaceInstance.java
@@ -5,6 +5,7 @@ import dev.devce.rocketnautics.content.RocketDimensions;
 import dev.devce.rocketnautics.content.orbit.universe.CubePlanet;
 import dev.devce.rocketnautics.content.orbit.universe.DeepSpacePosition;
 import dev.devce.rocketnautics.content.physics.SpaceTransitionHandler;
+import dev.devce.rocketnautics.network.DebugLogPayload;
 import dev.devce.rocketnautics.network.DeepSpacePositionPayload;
 import it.unimi.dsi.fastutil.doubles.DoubleObjectPair;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
@@ -48,6 +49,8 @@ public final class DeepSpaceInstance {
     private final Map<UUID, DoubleObjectPair<Vector3d>> pendingPhysics = new Object2ObjectOpenHashMap<>();
 
     private boolean isProcessingRetirement = false;
+
+    private final Deque<Float> velocityChangeLast20Ticks = new ArrayDeque<>();
 
     public DeepSpaceInstance(DeepSpaceData manager, int chunkSideLength, ChunkPos minCorner, long id) {
         this.manager = manager;
@@ -134,6 +137,12 @@ public final class DeepSpaceInstance {
                 position.init(manager.getUniverse(), position.getFrame(),
                         new TimeStampedPVCoordinates(coords.getDate(), coords.getPosition(), coords.getVelocity().add(velocityChange)));
                 manager.setDirty();
+                velocityChangeLast20Ticks.addFirst((float) velocityChange.getNorm());
+            } else {
+                velocityChangeLast20Ticks.addFirst(0f);
+            }
+            if (velocityChangeLast20Ticks.size() > 20) {
+                velocityChangeLast20Ticks.removeLast();
             }
         }
         AbsoluteDate lastTime = position.getLocalUniverseTime();
@@ -146,7 +155,8 @@ public final class DeepSpaceInstance {
             ServerLevel deepSpace = server.getLevel(RocketDimensions.DEEP_SPACE);
             List<ServerPlayer> players = deepSpace.getPlayers(p -> boundingBox().contains(p.position()));
             for (ServerPlayer player : players) {
-                PacketDistributor.sendToPlayer(player, DeepSpacePositionPayload.of(position, manager.getUniverse()));
+                double velChange = velocityChangeLast20Ticks.stream().mapToDouble(f -> f).sum();
+                PacketDistributor.sendToPlayer(player, DeepSpacePositionPayload.of(position, manager.getUniverse()), new DebugLogPayload("Recent acceleration: " + velChange, 0xFFFFFF));
             }
         }
         // check for planetary intersection (this should be last)

--- a/src/main/java/dev/devce/rocketnautics/content/orbit/universe/DeepSpacePosition.java
+++ b/src/main/java/dev/devce/rocketnautics/content/orbit/universe/DeepSpacePosition.java
@@ -89,7 +89,7 @@ public class DeepSpacePosition {
                 // then round the solved time to the nearest tick?
                 double transitionTicks;
                 try {
-                    transitionTicks = SOLVER.solve(10, func, 0, timescale);
+                    transitionTicks = SOLVER.solve(10, func, Math.min(timescale, 0), Math.max(timescale, 0));
                 } catch (MathIllegalStateException e) {
                     transitionTicks = lastCall.get();
                 }

--- a/src/main/java/dev/devce/rocketnautics/content/orbit/universe/PlanetDimensionData.java
+++ b/src/main/java/dev/devce/rocketnautics/content/orbit/universe/PlanetDimensionData.java
@@ -1,18 +1,40 @@
 package dev.devce.rocketnautics.content.orbit.universe;
 
-import com.mojang.serialization.Codec;
+import dev.devce.rocketnautics.api.orbit.AllowedTransfer;
+import dev.devce.rocketnautics.api.orbit.AtmosphereFlags;
+import dev.ryanhcode.sable.physics.config.dimension_physics.BezierResourceFunction;
+import it.unimi.dsi.fastutil.ints.Int2ObjectAVLTreeMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectSortedMap;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Locale;
+import java.util.*;
 
-public record PlanetDimensionData(@NotNull ResourceKey<Level> key, AllowedTransfer allowedTransfer, int transitionHeight,
+public record PlanetDimensionData(@NotNull ResourceKey<Level> key, @NotNull AllowedTransfer allowedTransfer,
+                                  int transitionHeight, @NotNull Int2ObjectSortedMap<EnumSet<AtmosphereFlags>> atmosphere,
                                   boolean renderUniverseInDimension, int dimensionDayTimeControllerID,
-                                  boolean applyGravityCorrectionToEntities) {
+                                  boolean applyGravityCorrectionToEntities, @NotNull BezierResourceFunction entityDragMultiplier) {
+
+    private static final StreamCodec<FriendlyByteBuf, BezierResourceFunction.BezierPoint> pointCodec = StreamCodec.of(
+            (buf, v) -> {
+                buf.writeDouble(v.altitude());
+                buf.writeDouble(v.value());
+                buf.writeDouble(v.slope());
+            }, buf -> {
+                double alt = buf.readDouble();
+                double val = buf.readDouble();
+                double slope = buf.readDouble();
+                return new BezierResourceFunction.BezierPoint(alt, val, slope);
+            }
+    );
+
+    // always evaluates to 1
+    public static final BezierResourceFunction EMPTY_BEZIER = new BezierResourceFunction(List.of());
 
     public boolean controlsDimensionDayTime() {
         return dimensionDayTimeControllerID >= 0;
@@ -22,36 +44,26 @@ public record PlanetDimensionData(@NotNull ResourceKey<Level> key, AllowedTransf
         buf.writeResourceKey(key);
         buf.writeEnum(allowedTransfer);
         buf.writeVarInt(transitionHeight);
+        buf.writeMap(atmosphere, ByteBufCodecs.INT, (b, c) -> b.writeEnumSet(c, AtmosphereFlags.class));
         buf.writeBoolean(renderUniverseInDimension);
         buf.writeVarInt(dimensionDayTimeControllerID);
         buf.writeBoolean(applyGravityCorrectionToEntities);
+        buf.writeCollection(entityDragMultiplier.getPoints(), pointCodec);
     }
 
     public static PlanetDimensionData read(FriendlyByteBuf buf) {
         ResourceKey<Level> key = buf.readResourceKey(Registries.DIMENSION);
         AllowedTransfer allowedTransfer = buf.readEnum(AllowedTransfer.class);
         int transitionHeight = buf.readVarInt();
+        Map<Integer, EnumSet<AtmosphereFlags>> map = buf.readMap(ByteBufCodecs.INT, b -> b.readEnumSet(AtmosphereFlags.class));
         boolean renderUniverseInDimension = buf.readBoolean();
         int controlDimensionDayTimeID = buf.readVarInt();
         boolean applyGravityCorrectionToEntities = buf.readBoolean();
-        return new PlanetDimensionData(key, allowedTransfer, transitionHeight, renderUniverseInDimension, controlDimensionDayTimeID, applyGravityCorrectionToEntities);
+        ArrayList<BezierResourceFunction.BezierPoint> entityDragPoints = buf.readCollection(ArrayList::new, pointCodec);
+        return new PlanetDimensionData(key, allowedTransfer,
+                transitionHeight, new Int2ObjectAVLTreeMap<>(map),
+                renderUniverseInDimension, controlDimensionDayTimeID,
+                applyGravityCorrectionToEntities, entityDragPoints.isEmpty() ? EMPTY_BEZIER : new BezierResourceFunction(entityDragPoints));
     }
 
-    public enum AllowedTransfer implements StringRepresentable {
-        ALL, NONE, TO_SPACE, TO_DIMENSION;
-        public static final Codec<AllowedTransfer> CODEC = StringRepresentable.fromEnum(AllowedTransfer::values);
-
-        public boolean allowToSpace() {
-            return this == ALL || this == TO_SPACE;
-        }
-
-        public boolean allowToDimension() {
-            return this == ALL || this == TO_DIMENSION;
-        }
-
-        @Override
-        public @NotNull String getSerializedName() {
-            return name().toLowerCase(Locale.ROOT);
-        }
-    }
 }

--- a/src/main/java/dev/devce/rocketnautics/content/orbit/universe/StandardUniverseProvider.java
+++ b/src/main/java/dev/devce/rocketnautics/content/orbit/universe/StandardUniverseProvider.java
@@ -72,7 +72,7 @@ public final class StandardUniverseProvider {
                 .setDimensionTransferHeight(20000)
                 .setCircularOrbit(lunarMonthInOverworldDays * overworldDaynightCycleLengthSeconds, Vector3D.PLUS_J)
                 .setRadius(overworldRadius / 4)
-                .setTidalLocked(new Rotation(Vector3D.PLUS_K, Vector3D.PLUS_I))
+                .setTidalLocked()
                 .setPriority(0);
     }
 

--- a/src/main/java/dev/devce/rocketnautics/content/orbit/universe/StandardUniverseProvider.java
+++ b/src/main/java/dev/devce/rocketnautics/content/orbit/universe/StandardUniverseProvider.java
@@ -1,12 +1,16 @@
 package dev.devce.rocketnautics.content.orbit.universe;
 
 import dev.devce.rocketnautics.RocketNautics;
+import dev.devce.rocketnautics.api.orbit.AtmosphereFlags;
 import dev.devce.rocketnautics.content.RocketDimensions;
 import dev.devce.rocketnautics.content.orbit.universe.builder.PlanetDefinitionBuilder;
 import dev.devce.rocketnautics.content.orbit.universe.builder.UniverseDefinitionBuilder;
+import dev.ryanhcode.sable.physics.config.dimension_physics.BezierResourceFunction;
 import net.minecraft.world.level.Level;
 import org.hipparchus.geometry.euclidean.threed.Rotation;
 import org.hipparchus.geometry.euclidean.threed.Vector3D;
+
+import java.util.EnumSet;
 
 public final class StandardUniverseProvider {
     private static final double solRadius = 300_000_000D;
@@ -54,7 +58,11 @@ public final class StandardUniverseProvider {
                 .setClouds(true)
                 .setParentIsShadowLightSource()
                 .setLinkedDimension(Level.OVERWORLD)
-                .setDimensionTransferHeight(20000)
+                .setDimensionTransferHeight(20_000)
+                .addEntityDragPoint(4_000, 1, 0)
+                .addEntityDragPoint(7_000, 0, -0.0006)
+                .setAtmosphereFlagsBelow(5_000, AtmosphereFlags.empty())
+                .setAtmosphereFlagsBelow(21_000, EnumSet.of(AtmosphereFlags.DROWNING, AtmosphereFlags.LOW_DENSITY))
                 .setRadius(overworldRadius)
                 .setCircularOrbit(overworldOrbitalYearInOverworldDays * overworldDaynightCycleLengthSeconds, Vector3D.PLUS_J)
                 .setRotationPeriod(Vector3D.MINUS_J, overworldDaynightCycleLengthSeconds)
@@ -70,6 +78,9 @@ public final class StandardUniverseProvider {
                 .setDimensionDayTimeController("sol")
                 .setApplyGravityCorrectionToEntities(true)
                 .setDimensionTransferHeight(20000)
+                .addEntityDragPoint(4_000, 1, 0)
+                .addEntityDragPoint(7_000, 0, -0.0006)
+                .setAtmosphereFlagsBelow(21_000, EnumSet.of(AtmosphereFlags.DROWNING, AtmosphereFlags.LOW_DENSITY))
                 .setCircularOrbit(lunarMonthInOverworldDays * overworldDaynightCycleLengthSeconds, Vector3D.PLUS_J)
                 .setRadius(overworldRadius / 4)
                 .setTidalLocked()

--- a/src/main/java/dev/devce/rocketnautics/content/orbit/universe/builder/PlanetDefinitionBuilder.java
+++ b/src/main/java/dev/devce/rocketnautics/content/orbit/universe/builder/PlanetDefinitionBuilder.java
@@ -315,12 +315,12 @@ public class PlanetDefinitionBuilder {
     }
 
     public PlanetDefinitionBuilder setTidalLocked() {
-        this.rotation = Optional.of(SerializableRotation.SpinOrbitResonance.of(1));
+        this.rotation = Optional.of(SerializableRotation.SpinOrbitResonance.of(-1));
         return this;
     }
 
     public PlanetDefinitionBuilder setTidalLocked(Rotation correction) {
-        this.rotation = Optional.of(SerializableRotation.SpinOrbitResonance.of(1, null, correction));
+        this.rotation = Optional.of(SerializableRotation.SpinOrbitResonance.of(-1, null, correction));
         return this;
     }
 

--- a/src/main/java/dev/devce/rocketnautics/content/orbit/universe/builder/PlanetDefinitionBuilder.java
+++ b/src/main/java/dev/devce/rocketnautics/content/orbit/universe/builder/PlanetDefinitionBuilder.java
@@ -2,12 +2,16 @@ package dev.devce.rocketnautics.content.orbit.universe.builder;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import dev.devce.rocketnautics.api.orbit.AllowedTransfer;
+import dev.devce.rocketnautics.api.orbit.AtmosphereFlags;
 import dev.devce.rocketnautics.api.orbit.DeepSpaceHelper;
 import dev.devce.rocketnautics.api.orbit.FrameTree;
 import dev.devce.rocketnautics.content.orbit.universe.CubePlanet;
 import dev.devce.rocketnautics.content.orbit.universe.PlanetDimensionData;
 import dev.devce.rocketnautics.content.orbit.universe.PlanetExtras;
 import dev.devce.rocketnautics.content.orbit.universe.PointGravitySource;
+import dev.ryanhcode.sable.physics.config.dimension_physics.BezierResourceFunction;
+import it.unimi.dsi.fastutil.ints.*;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
@@ -20,6 +24,8 @@ import org.orekit.time.AbsoluteDate;
 import org.orekit.utils.TimeStampedAngularCoordinates;
 import org.orekit.utils.TimeStampedPVCoordinates;
 
+import java.util.EnumSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.IntFunction;
@@ -44,11 +50,13 @@ public class PlanetDefinitionBuilder {
 
     // dimension data
     public Optional<ResourceKey<Level>> linkedDimension = Optional.empty();
-    public Optional<PlanetDimensionData.AllowedTransfer> allowedTransfer = Optional.empty();
+    public Optional<AllowedTransfer> allowedTransfer = Optional.empty();
     public Optional<Integer> transferHeight = Optional.empty();
+    public Optional<Int2ObjectRBTreeMap<EnumSet<AtmosphereFlags>>> atmosphere = Optional.empty();
     public Optional<Boolean> renderUniverseInDimension = Optional.empty();
     public Optional<String> dimensionDayTimeControllerName = Optional.empty();
     public Optional<Boolean> applyGravityCorrectionToEntities = Optional.empty();
+    public Optional<BezierResourceFunction> entityDragMultiplier = Optional.empty();
     // planet extras
     public Optional<Boolean> clouds = Optional.empty();
     public Optional<Boolean> star = Optional.empty();
@@ -96,10 +104,12 @@ public class PlanetDefinitionBuilder {
             this.linkedDimension = dimData.get().key();
             this.allowedTransfer = dimData.get().allowedTransfer();
             this.transferHeight = dimData.get().transitionHeight();
+            this.atmosphere = dimData.get().atmosphere();
             this.renderUniverseInDimension = dimData.get().renderUniverseInDimension();
             this.dimensionDayTimeControllerName = dimData.get().dimensionDayTimeControllerName();
             dimensionDayTimeControllerName.ifPresent(dependencies::add);
             this.applyGravityCorrectionToEntities = dimData.get().applyGravityCorrectionToEntities();
+            this.entityDragMultiplier = dimData.get().entityDragMultiplier();
         }
         if (extras.isPresent()) {
             this.clouds = extras.get().clouds();
@@ -131,7 +141,7 @@ public class PlanetDefinitionBuilder {
     }
 
     protected Optional<SerializableDimensionData> serializeDimensionData() {
-        return SerializableDimensionData.of(linkedDimension, allowedTransfer, transferHeight, renderUniverseInDimension, dimensionDayTimeControllerName, applyGravityCorrectionToEntities);
+        return SerializableDimensionData.of(linkedDimension, allowedTransfer, transferHeight, atmosphere, renderUniverseInDimension, dimensionDayTimeControllerName, applyGravityCorrectionToEntities, entityDragMultiplier);
     }
 
     protected Optional<SerializablePlanetExtras> serializePlanetExtras() {
@@ -190,7 +200,6 @@ public class PlanetDefinitionBuilder {
         } else {
             roi = Double.POSITIVE_INFINITY;
         }
-        ResourceLocation override;
         destination.gravitySource(new PointGravitySource(ourFrame, mu, roi));
         CubePlanet p = new CubePlanet(ourFrame, radius, angularCoordinates, constructDimensionData(destination), useTextureOverride.orElse(true) ? textureOverride.orElse(null) : null, constructExtras(destination));
         destination.cubePlanet(p);
@@ -206,7 +215,11 @@ public class PlanetDefinitionBuilder {
                 id = f.getId();
             }
         }
-        return new PlanetDimensionData(linkedDimension.get(), allowedTransfer.orElse(PlanetDimensionData.AllowedTransfer.NONE), transferHeight.orElse(20_000), renderUniverseInDimension.orElse(false), id, applyGravityCorrectionToEntities.orElse(false));
+        return new PlanetDimensionData(linkedDimension.get(), allowedTransfer.orElse(AllowedTransfer.NONE),
+                transferHeight.orElse(20_000),
+                atmosphere.map(m -> (Int2ObjectSortedMap<EnumSet<AtmosphereFlags>>) new Int2ObjectAVLTreeMap<>(m)).orElse(Int2ObjectSortedMaps.emptyMap()), // bake into an AVL map for improved search performance
+                renderUniverseInDimension.orElse(false), id, applyGravityCorrectionToEntities.orElse(false),
+                entityDragMultiplier.orElse(PlanetDimensionData.EMPTY_BEZIER));
     }
 
     protected PlanetExtras constructExtras(UniverseDefinitionBuilder destination) {
@@ -221,10 +234,10 @@ public class PlanetDefinitionBuilder {
     }
 
     public PlanetDefinitionBuilder setLinkedDimension(@Nullable ResourceKey<Level> linkedDimension) {
-        return setLinkedDimension(linkedDimension, PlanetDimensionData.AllowedTransfer.ALL);
+        return setLinkedDimension(linkedDimension, AllowedTransfer.ALL);
     }
 
-    public PlanetDefinitionBuilder setLinkedDimension(@Nullable ResourceKey<Level> linkedDimension, PlanetDimensionData.AllowedTransfer allowedTransfer) {
+    public PlanetDefinitionBuilder setLinkedDimension(@Nullable ResourceKey<Level> linkedDimension, AllowedTransfer allowedTransfer) {
         this.linkedDimension = Optional.ofNullable(linkedDimension);
         this.allowedTransfer = Optional.ofNullable(allowedTransfer);
         return this;
@@ -390,6 +403,27 @@ public class PlanetDefinitionBuilder {
      */
     public PlanetDefinitionBuilder setMu(double mu) {
         this.mu = Optional.of(mu);
+        return this;
+    }
+
+    public PlanetDefinitionBuilder setAtmosphereFlagsBelow(int altitude, EnumSet<AtmosphereFlags> flags) {
+        if (atmosphere.isEmpty()) {
+            atmosphere = Optional.of(new Int2ObjectRBTreeMap<>());
+        }
+        atmosphere.get().put(altitude, flags);
+        return this;
+    }
+
+    public PlanetDefinitionBuilder addEntityDragPoint(double altitude, double value, double slope) {
+        addEntityDragPoint(new BezierResourceFunction.BezierPoint(altitude, value, slope));
+        return this;
+    }
+
+    public PlanetDefinitionBuilder addEntityDragPoint(BezierResourceFunction.BezierPoint point) {
+        if (entityDragMultiplier.isEmpty()) {
+            entityDragMultiplier = Optional.of(new BezierResourceFunction());
+        }
+        entityDragMultiplier.get().addPoint(point);
         return this;
     }
 

--- a/src/main/java/dev/devce/rocketnautics/content/orbit/universe/builder/SerializableDimensionData.java
+++ b/src/main/java/dev/devce/rocketnautics/content/orbit/universe/builder/SerializableDimensionData.java
@@ -2,33 +2,47 @@ package dev.devce.rocketnautics.content.orbit.universe.builder;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import dev.devce.rocketnautics.content.orbit.universe.PlanetDimensionData;
+import dev.devce.rocketnautics.api.orbit.AllowedTransfer;
+import dev.devce.rocketnautics.api.orbit.AtmosphereFlags;
+import dev.ryanhcode.sable.physics.config.dimension_physics.BezierResourceFunction;
+import it.unimi.dsi.fastutil.ints.Int2ObjectRBTreeMap;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.util.ExtraCodecs;
 import net.minecraft.world.level.Level;
 
-import java.util.Optional;
+import java.util.*;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-public record SerializableDimensionData(Optional<ResourceKey<Level>> key, Optional<PlanetDimensionData.AllowedTransfer> allowedTransfer,
-                                        Optional<Integer> transitionHeight,
+public record SerializableDimensionData(Optional<ResourceKey<Level>> key, Optional<AllowedTransfer> allowedTransfer,
+                                        Optional<Integer> transitionHeight, Optional<Int2ObjectRBTreeMap<EnumSet<AtmosphereFlags>>> atmosphere,
                                         Optional<Boolean> renderUniverseInDimension, Optional<String> dimensionDayTimeControllerName,
-                                        Optional<Boolean> applyGravityCorrectionToEntities) {
+                                        Optional<Boolean> applyGravityCorrectionToEntities, Optional<BezierResourceFunction> entityDragMultiplier) {
     public static final Codec<SerializableDimensionData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Level.RESOURCE_KEY_CODEC.optionalFieldOf("linked_dimension").forGetter(p -> p.key),
-            PlanetDimensionData.AllowedTransfer.CODEC.optionalFieldOf("allowed_transfer").forGetter(p -> p.allowedTransfer),
+            AllowedTransfer.CODEC.optionalFieldOf("allowed_transfer").forGetter(p -> p.allowedTransfer),
             ExtraCodecs.POSITIVE_INT.optionalFieldOf("dimension_transfer_height").forGetter(p -> p.transitionHeight),
+            Codec.unboundedMap(Codec.STRING.xmap(Integer::parseInt, String::valueOf), AtmosphereFlags.CODEC.listOf().xmap(SerializableDimensionData::properCopy, ArrayList::new)).xmap(Int2ObjectRBTreeMap::new, i -> i).optionalFieldOf("atmosphere_composition").forGetter(p -> p.atmosphere),
             Codec.BOOL.optionalFieldOf("render_universe_in_dimension").forGetter(p -> p.renderUniverseInDimension),
             Codec.STRING.optionalFieldOf("dimension_day_time_controller_name").forGetter(p -> p.dimensionDayTimeControllerName),
-            Codec.BOOL.optionalFieldOf("apply_gravity_correction_to_entities_in_dimension").forGetter(p -> p.applyGravityCorrectionToEntities)
+            Codec.BOOL.optionalFieldOf("apply_gravity_correction_to_entities_in_dimension").forGetter(p -> p.applyGravityCorrectionToEntities),
+            BezierResourceFunction.CODEC.optionalFieldOf("entity_drag_multiplier").forGetter(p -> p.entityDragMultiplier)
     ).apply(instance, SerializableDimensionData::new));
 
-    public static Optional<SerializableDimensionData> of(Optional<ResourceKey<Level>> key, Optional<PlanetDimensionData.AllowedTransfer> allowedTransfer, Optional<Integer> transitionHeight,
+    public static Optional<SerializableDimensionData> of(Optional<ResourceKey<Level>> key, Optional<AllowedTransfer> allowedTransfer,
+                                                         Optional<Integer> transitionHeight, Optional<Int2ObjectRBTreeMap<EnumSet<AtmosphereFlags>>> atmosphere,
                                                          Optional<Boolean> renderUniverseInDimension, Optional<String> dimensionDayTimeControllerName,
-                                                         Optional<Boolean> applyGravityCorrectionToEntities) {
-        if (key.isEmpty() && transitionHeight.isEmpty() && renderUniverseInDimension.isEmpty() && dimensionDayTimeControllerName.isEmpty() && applyGravityCorrectionToEntities.isEmpty()) {
+                                                         Optional<Boolean> applyGravityCorrectionToEntities, Optional<BezierResourceFunction> entityDragMultiplier) {
+        if (key.isEmpty() && allowedTransfer.isEmpty() &&
+                transitionHeight.isEmpty() && atmosphere.isEmpty() &&
+                renderUniverseInDimension.isEmpty() && dimensionDayTimeControllerName.isEmpty() &&
+                applyGravityCorrectionToEntities.isEmpty() && entityDragMultiplier.isEmpty()) {
             return Optional.empty();
         }
-        return Optional.of(new SerializableDimensionData(key, allowedTransfer, transitionHeight, renderUniverseInDimension, dimensionDayTimeControllerName, applyGravityCorrectionToEntities));
+        return Optional.of(new SerializableDimensionData(key, allowedTransfer, transitionHeight, atmosphere, renderUniverseInDimension, dimensionDayTimeControllerName, applyGravityCorrectionToEntities, entityDragMultiplier));
+    }
+
+    private static EnumSet<AtmosphereFlags> properCopy(Collection<AtmosphereFlags> collection) {
+        if (collection.isEmpty()) return AtmosphereFlags.empty();
+        return EnumSet.copyOf(collection);
     }
 }

--- a/src/main/java/dev/devce/rocketnautics/content/physics/GlobalSpacePhysicsHandler.java
+++ b/src/main/java/dev/devce/rocketnautics/content/physics/GlobalSpacePhysicsHandler.java
@@ -1,5 +1,6 @@
 package dev.devce.rocketnautics.content.physics;
 
+import com.simibubi.create.content.equipment.armor.BacktankUtil;
 import dev.devce.rocketnautics.RocketNautics;
 import dev.devce.rocketnautics.api.orbit.AtmosphereFlags;
 import dev.devce.rocketnautics.api.orbit.DeepSpaceHelper;
@@ -27,6 +28,7 @@ import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.entity.living.LivingBreatheEvent;
+import net.neoforged.neoforge.event.entity.living.LivingFallEvent;
 import net.neoforged.neoforge.event.tick.EntityTickEvent;
 import net.neoforged.neoforge.network.PacketDistributor;
 import org.jetbrains.annotations.NotNull;
@@ -409,6 +411,15 @@ public class GlobalSpacePhysicsHandler {
         }
     }
 
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public static void onFallDamage(LivingFallEvent event) {
+        if (DeepSpaceHelper.getDataForDimension(event.getEntity().level()).map(PlanetDimensionData::applyGravityCorrectionToEntities).orElse(false)) {
+            double gravity = DimensionPhysicsData.getGravity(event.getEntity().level()).y();
+            double normalGravity = -11f;
+            event.setDistance((float) (event.getDistance() * gravity / normalGravity));
+        }
+    }
+
     public static @NotNull EnumSet<AtmosphereFlags> getFlags(LivingEntity entity) {
         if (DeepSpaceHelper.isDeepSpace(entity.level())) {
             return EnumSet.of(AtmosphereFlags.DROWNING, AtmosphereFlags.LOW_DENSITY);
@@ -420,6 +431,7 @@ public class GlobalSpacePhysicsHandler {
     }
 
     public static boolean shouldDisplayTimer(Player player) {
+        if (BacktankUtil.getAllWithAir(player).isEmpty()) return false;
         return getFlags(player).contains(AtmosphereFlags.DROWNING) || JetpackItem.isActive(player) || LegThrustersItem.legThrustersActive(player);
     }
 

--- a/src/main/java/dev/devce/rocketnautics/content/physics/GlobalSpacePhysicsHandler.java
+++ b/src/main/java/dev/devce/rocketnautics/content/physics/GlobalSpacePhysicsHandler.java
@@ -1,9 +1,11 @@
 package dev.devce.rocketnautics.content.physics;
 
 import dev.devce.rocketnautics.RocketNautics;
+import dev.devce.rocketnautics.api.orbit.AtmosphereFlags;
 import dev.devce.rocketnautics.api.orbit.DeepSpaceHelper;
 import dev.devce.rocketnautics.content.items.JetpackItem;
 import dev.devce.rocketnautics.content.items.LegThrustersItem;
+import dev.devce.rocketnautics.content.orbit.universe.PlanetDimensionData;
 import dev.devce.rocketnautics.network.ReentryHeatPayload;
 import dev.devce.rocketnautics.registry.RocketParticles;
 import dev.ryanhcode.sable.api.physics.handle.RigidBodyHandle;
@@ -12,6 +14,7 @@ import dev.ryanhcode.sable.platform.SableEventPlatform;
 import dev.ryanhcode.sable.sublevel.ServerSubLevel;
 import dev.ryanhcode.sable.sublevel.SubLevel;
 import dev.ryanhcode.sable.physics.config.dimension_physics.DimensionPhysicsData;
+import it.unimi.dsi.fastutil.ints.Int2ObjectSortedMaps;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -26,12 +29,15 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.entity.living.LivingBreatheEvent;
 import net.neoforged.neoforge.event.tick.EntityTickEvent;
 import net.neoforged.neoforge.network.PacketDistributor;
+import org.jetbrains.annotations.NotNull;
 import org.joml.Quaterniond;
 import org.joml.Vector3d;
 
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.sounds.SoundSource;
 import dev.devce.rocketnautics.registry.RocketSounds;
+
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -395,7 +401,7 @@ public class GlobalSpacePhysicsHandler {
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public static void onLivingBreathe(LivingBreatheEvent event) {
         if (event.canBreathe()) {
-            if (!canBreathe(event.getEntity())) {
+            if (getFlags(event.getEntity()).contains(AtmosphereFlags.DROWNING)) {
                 if ((!(event.getEntity() instanceof Player player) || !player.getAbilities().invulnerable)) {
                     event.setCanBreathe(false);
                 }
@@ -403,12 +409,18 @@ public class GlobalSpacePhysicsHandler {
         }
     }
 
-    public static boolean canBreathe(LivingEntity entity) {
-        return calculateGravityFactor(entity.level(), entity.getY()) < 0.5;
+    public static @NotNull EnumSet<AtmosphereFlags> getFlags(LivingEntity entity) {
+        if (DeepSpaceHelper.isDeepSpace(entity.level())) {
+            return EnumSet.of(AtmosphereFlags.DROWNING, AtmosphereFlags.LOW_DENSITY);
+        }
+        var data = DeepSpaceHelper.getDataForDimension(entity.level()).map(PlanetDimensionData::atmosphere).orElse(Int2ObjectSortedMaps.emptyMap());
+        var flags = data.tailMap((int) entity.getY()).firstEntry();
+        if (flags == null) return EnumSet.noneOf(AtmosphereFlags.class);
+        return flags.getValue();
     }
 
     public static boolean shouldDisplayTimer(Player player) {
-        return !canBreathe(player) || JetpackItem.isActive(player) || LegThrustersItem.legThrustersActive(player);
+        return getFlags(player).contains(AtmosphereFlags.DROWNING) || JetpackItem.isActive(player) || LegThrustersItem.legThrustersActive(player);
     }
 
 //    /**

--- a/src/main/java/dev/devce/rocketnautics/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/devce/rocketnautics/mixin/LivingEntityMixin.java
@@ -7,6 +7,8 @@ import com.llamalad7.mixinextras.sugar.ref.LocalDoubleRef;
 import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import dev.devce.rocketnautics.RocketConfig;
 import dev.devce.rocketnautics.RocketNautics;
+import dev.devce.rocketnautics.api.orbit.DeepSpaceHelper;
+import dev.devce.rocketnautics.content.orbit.universe.PlanetDimensionData;
 import dev.devce.rocketnautics.content.physics.GlobalSpacePhysicsHandler;
 import dev.ryanhcode.sable.physics.config.dimension_physics.DimensionPhysicsData;
 import net.minecraft.world.entity.Entity;
@@ -31,8 +33,8 @@ public abstract class LivingEntityMixin extends Entity {
         int limit = RocketConfig.SERVER.entitySpeedLimit.get();
         // note that delta movement is in m/t not m/s, so we multiply our speed squared by a correction factor of 400 (20 * 20)
         if (!instance.onGround() && 400 * (x * x + y * y + z * z) <= limit * limit) {
-            double pressure = 1 - GlobalSpacePhysicsHandler.calculateGravityFactor(level(), instance.getY());
-            if (pressure < 1) {
+            double pressure = DeepSpaceHelper.getDataForDimension(instance.level()).map(PlanetDimensionData::entityDragMultiplier).orElse(PlanetDimensionData.EMPTY_BEZIER).evaluateFunction(instance.getY());
+            if (pressure != 1) {
                 double drag1 = 1 - (1 - f3) * pressure;
                 double drag2 = 1 - 0.02 * pressure;
                 original.call(instance, vec35.x * drag1, this instanceof FlyingAnimal ? d2 * drag1 : d2 * drag2, vec35.z * drag1);

--- a/src/main/java/dev/devce/rocketnautics/mixin/SubLevelPhysicsSystemMixin.java
+++ b/src/main/java/dev/devce/rocketnautics/mixin/SubLevelPhysicsSystemMixin.java
@@ -6,6 +6,7 @@ import dev.devce.rocketnautics.content.orbit.DeepSpaceData;
 import dev.devce.rocketnautics.content.orbit.DeepSpaceInstance;
 import dev.ryanhcode.sable.api.physics.handle.RigidBodyHandle;
 import dev.ryanhcode.sable.api.sublevel.ServerSubLevelContainer;
+import dev.ryanhcode.sable.companion.math.JOMLConversion;
 import dev.ryanhcode.sable.sublevel.ServerSubLevel;
 import dev.ryanhcode.sable.sublevel.system.SubLevelPhysicsSystem;
 import org.jetbrains.annotations.NotNull;
@@ -34,7 +35,7 @@ public abstract class SubLevelPhysicsSystemMixin {
         DeepSpaceInstance handling = DeepSpaceData.getInstance(container.getLevel().getServer()).getInstanceForPos((int) position.x(), (int) position.z());
         RigidBodyHandle handle = this.getPhysicsHandle(subLevel);
         Vector3d velocity = handle.getLinearVelocity(new Vector3d());
-        if (handling == null) {
+        if (handling == null || !handling.boundingBox().contains(JOMLConversion.toMojang(position))) {
             // no movement allowed if you're not in an instance.
             handle.addLinearAndAngularVelocity(velocity.negate(), new Vector3d());
             return;
@@ -44,7 +45,8 @@ public abstract class SubLevelPhysicsSystemMixin {
         // if this projection lands outside the box radius, cancel the component of velocity moving outward, and halve the orthogonal component of velocity.
         Vector3dc center = handling.getCenter();
         Vector3d offset = position.sub(center, new Vector3d());
-        if (offset.lengthSquared() <= 1e-20 || (offset.length() + subLevel.boundingBox().size().length()) * 2 <= handling.getSideLength()) {
+        double overshoot = (offset.length() + subLevel.boundingBox().size().length()) * 2 - handling.getSideLength();
+        if (offset.lengthSquared() <= 1e-20 || overshoot <= 0) {
             // just register our mass, skipping any calculation
             handling.applyVelocity(subLevel.getUniqueId(), offset.zero(), subLevel.getMassTracker().getMass());
             return;
@@ -53,8 +55,10 @@ public abstract class SubLevelPhysicsSystemMixin {
         double dot = offset.dot(velocity);
         Vector3d aligned = offset.mul(dot, new Vector3d());
         Vector3d orthogonal = velocity.sub(aligned, new Vector3d());
-        if (dot < 0) {
-            aligned.zero(); // don't cancel velocity moving towards the center
+        if (dot <= 0) { // don't cancel velocity moving towards the center
+            aligned.zero();
+        } else if (overshoot > 1) { // pull objects that are too far out back towards the center
+            aligned.fma(Math.sqrt(overshoot), offset);
         }
         Vector3d cancelledComponent = orthogonal.mulAdd(0.5, aligned);
         handling.applyVelocity(subLevel.getUniqueId(), cancelledComponent, subLevel.getMassTracker().getMass());

--- a/wiki/Cube Planets.md
+++ b/wiki/Cube Planets.md
@@ -6,7 +6,7 @@ Certain fields are "paired" with other fields. This means that at least one of t
 
 While Cube Planets can be linked to custom dimensions, we do not provide any tools to add dimensions. However, datapacks are entirely capable of adding custom dimensions, and tutorials exist for this.
 
-### Fields
+## Fields
 
 **`parent`** (critical): The name of the parent body. If the planet has no parent body, such as `sol` by default, use `root` here.
 
@@ -14,40 +14,48 @@ While Cube Planets can be linked to custom dimensions, we do not provide any too
 
 **`radius`** (critical): The radius of the cube planet, equivalent to half its side length.
 
-**`mu`** (critical, paired with `acceleration_at_surface`) the standard gravitational parameter (μ) of this cube planet.
+**`mu`** (critical, paired with `acceleration_at_surface`): the standard gravitational parameter (μ) of this cube planet.
 
-**`acceleration_at_surface`** (critical, paired with `mu`) the acceleration that physics objects are subject to at a distance of `radius` from the center of the cube planet.
+**`acceleration_at_surface`** (critical, paired with `mu`): the acceleration that physics objects are subject to at a distance of `radius` from the center of the cube planet.
 
-**`position`** (critical) A [Celestial Position](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Celestial-Positions)
+**`position`** (critical): A [Celestial Position](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Celestial-Positions)
 
-**`rotation`** (critical) A [Celestial Rotation](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Celestial-Rotations)
+**`rotation`** (critical): A [Celestial Rotation](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Celestial-Rotations)
 
-**`dimension_data`** (optional) A compound object consisting of the following fields:
+**`dimension_data`** (optional): A compound object consisting of [these fields](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Cube-Planets#Dimension-Data-Fields). Each field can be overridden separately.
 
-> **`linked_dimension`** (critical) The resource location of the dimension linked to this cube planet.
->
-> **`allowed_transfer`** (optional, default `none`) Which transitions between deep space and the dimension are allowed. Options are `all`, `none`, `to_space`, and `to_dimension`.
-> 
-> **`dimension_transfer_height`** (optional, default `20_000`) The height of the transition point. Applies to both deep space and the dimension. Must be an integer.
-> 
-> **`render_universe_in_dimension`** (optional, default `false`) Whether the universe should render in the dimension's skybox. The dimension's default skybox must be manually disabled elsewhere.
-> 
-> **`dimension_day_time_controller_name`** (optional) The name of the celestial body that will be compared against to determine the time of day in the linked dimension. Recommended if the universe is rendered in the dimension.
-> 
-> **`apply_gravity_correction_to_entities_in_dimension`** (optional, default `false`) Whether a gravity correction should be applied to entities in the dimension. Normal gravity is assumed to be `11m/s^2` at surface because this is the Sable default, and the correction will be proportional to the ratio between this and the cube planet's acceleration at surface. The acceleration at surface can be derived from `mu`.
+**`planet_extras`** (optional): A compound object consisting of [these fields](https://github.com/CosmonauticsTeam/Create-Cosmonautics/wiki/Cube-Planets#Planet-Extras-Fields). Each field can be overridden separately.
 
-**`planet_extras`** (optional) A compound object consisting of the following fields:
+**`texture_override`** (optional): A resource location to a texture to use instead of generating the texture from biome data. Changing how the texture is generated from biome data is not yet supported.
 
-> **`is_star`** (optional, default `false`) Whether the cube planet is a star and should have a star render.
-> 
-> **`has_clouds`** (optional, default `false`) Whether the cube planet should have clouds render above its surface.
-> 
-> **`light_source_name`** (optional) The name of the celestial body that will be used to determine shadows cast across the planet's surface.
+**`use_texture_override`** (optional, default `true`): Whether the `texture_override` should actually be used, if it is present.
 
-**`texture_override`** (optional) A resource location to a texture to use instead of generating the texture from biome data. Changing how the texture is generated from biome data is not yet supported.
+**`priority`** (optional, default `1000`): The priority of this file in the "priority override" phase. Must be an integer. Cube planets added by the base mod have a priority of 0.
 
-**`use_texture_override`** (optional, default `true`) Whether the `texture_override` should actually be used, if it is present.
+**`disabled`** (optional, default `false`): Whether this planet should be loaded. Useful for disabling planets added by the base mod.
 
-**`priority`** (optional, default `1000`) The priority of this file in the "priority override" phase. Must be an integer. Cube planets added by the base mod have a priority of 0.
+### Dimension Data Fields
 
-**`disabled`** (optional, default `false`) Whether this planet should be loaded. Useful for disabling planets added by the base mod.
+**`linked_dimension`** (critical): The resource location of the dimension linked to this cube planet.
+
+**`allowed_transfer`** (optional, default `none`): Which transitions between deep space and the dimension are allowed. Options are `all`, `none`, `to_space`, and `to_dimension`.
+
+**`dimension_transfer_height`** (optional, default `20_000`): The height of the transition point. Applies to both deep space and the dimension. Must be an integer.
+
+**`atmosphere_composition`** (optional): A map of heights to atmosphere composition flags. Each height in the map controls the "bucket" of altitudes between it and the height below. Associated flags are a collection of supported flags. Options are `low_density`, `drowning`. Currently `low_density` controls whether the quadruple efficiency bonus of copper leg thrusters applies, while `drowning` activates our standard no atmosphere behavior of causing the player to start drowning.
+
+**`render_universe_in_dimension`** (optional, default `false`): Whether the universe should render in the dimension's skybox. The dimension's default skybox must be manually disabled elsewhere.
+
+**`dimension_day_time_controller_name`** (optional): The name of the celestial body that will be compared against to determine the time of day in the linked dimension. Recommended if the universe is rendered in the dimension.
+
+**`apply_gravity_correction_to_entities_in_dimension`** (optional, default `false`): Whether a gravity correction should be applied to entities in the dimension. Normal gravity is assumed to be `11m/s^2` at surface because this is the Sable default, and the correction will be proportional to the ratio between this and the cube planet's acceleration at surface. The acceleration at surface can be derived from `mu`.
+
+**`entity_drag_multiplier`** (optional): A list of bezier control points for controlling entity drag with altitude, equivalent to Sable's native `pressure_function` in dimension physics data. Each point has `altitude` (y-level), `value` (multiplier to entity drag at that altitude), and `slope` (rate of change). Omit this field for no modifications to entity drag.
+
+### Planet Extras Fields
+
+**`is_star`** (optional, default `false`): Whether the cube planet is a star and should have a star render.
+
+**`has_clouds`** (optional, default `false`): Whether the cube planet should have clouds render above its surface.
+
+**`light_source_name`** (optional): The name of the celestial body that will be used to determine shadows cast across the planet's surface.

--- a/wiki/Cube Planets.md
+++ b/wiki/Cube Planets.md
@@ -48,7 +48,7 @@ While Cube Planets can be linked to custom dimensions, we do not provide any too
 
 **`dimension_day_time_controller_name`** (optional): The name of the celestial body that will be compared against to determine the time of day in the linked dimension. Recommended if the universe is rendered in the dimension.
 
-**`apply_gravity_correction_to_entities_in_dimension`** (optional, default `false`): Whether a gravity correction should be applied to entities in the dimension. Normal gravity is assumed to be `11m/s^2` at surface because this is the Sable default, and the correction will be proportional to the ratio between this and the cube planet's acceleration at surface. The acceleration at surface can be derived from `mu`.
+**`apply_gravity_correction_to_entities_in_dimension`** (optional, default `false`): Whether a gravity correction should be applied to entities in the dimension. Normal gravity is assumed to be `11m/s^2` at surface because this is the Sable default, and the correction will be proportional to the ratio between this and the gravity found in the dimension's physics data supplied by Sable.
 
 **`entity_drag_multiplier`** (optional): A list of bezier control points for controlling entity drag with altitude, equivalent to Sable's native `pressure_function` in dimension physics data. Each point has `altitude` (y-level), `value` (multiplier to entity drag at that altitude), and `slope` (rate of change). Omit this field for no modifications to entity drag.
 


### PR DESCRIPTION
### What Changed
Fixed the moon's tidal lock rotating the wrong direction
Fixed a critical bug with deep space instancing and several minor bugs
Fixed relative inertial dampeners dragging the player through colliders
Fixed jetpack capacity gained from the Capacity enchant being impossible to fill with lava
Fixed fall damage in low gravity environments being extremely punishing

The invisible box that you are in while in deep space now has a very simple render when you get close to it.
Atmosphere composition and entity drag changes are now data driven.
Improved the hologram table's rendering
### Why this change
Having the invisible box render when you're close to it should hopefully make its existence and the fact that it is not a bug more clear to players.
More data driven planet configuration is good.
New hologram rendering approach makes planetary orbits independent of your orbit prediction, allowing them to be rendered outside of deep space. The synchronized future position predictions are also tweaked to hopefully improve usefulness.