### PR TITLE
Add configurable planet surface mapping

### DIFF
--- a/src/generated/resources/data/rocketnautics/universe_planets/overworld.json
+++ b/src/generated/resources/data/rocketnautics/universe_planets/overworld.json
@@ -11,6 +11,9 @@
       "5000": []
     },
     "dimension_transfer_height": 20000,
+    "surface_map_center_x": 0.0,
+    "surface_map_center_z": 0.0,
+    "surface_map_radius": 30000000.0,
     "entity_drag_multiplier": [
       {
         "altitude": 4000.0,

--- a/src/main/java/dev/devce/rocketnautics/api/orbit/DeepSpaceHelper.java
+++ b/src/main/java/dev/devce/rocketnautics/api/orbit/DeepSpaceHelper.java
@@ -253,8 +253,15 @@ public class DeepSpaceHelper {
     public static Pair<TimeStampedPVCoordinates, Rotation> localPositionToGlobalPositionAndRotation(Vector3dc localPosition, @Nullable Vector3dc localVelocity, CubePlanet planet, AbsoluteDate date) {
         Rotation rotation = planet.getRotationAtTime(date);
         rotation = rotation.compose(new Rotation(Vector3D.PLUS_J, Vector3D.PLUS_K), RotationConvention.VECTOR_OPERATOR);
-        Vector3d scaledPosition = localPosition.mul(planet.radius() / 30_000_000, new Vector3d());
-        Vector3D unrotatedPosition = new Vector3D(scaledPosition.x(), localPosition.y() + planet.radius(), scaledPosition.z());
+        PlanetDimensionData dimensionData = planet.linkedDimension();
+        double mapCenterX = dimensionData == null ? PlanetDimensionData.DEFAULT_SURFACE_MAP_CENTER_X : dimensionData.surfaceMapCenterX();
+        double mapCenterZ = dimensionData == null ? PlanetDimensionData.DEFAULT_SURFACE_MAP_CENTER_Z : dimensionData.surfaceMapCenterZ();
+        double mapRadius = dimensionData == null ? PlanetDimensionData.DEFAULT_SURFACE_MAP_RADIUS : dimensionData.surfaceMapRadius();
+        double scale = planet.radius() / mapRadius;
+        Vector3D unrotatedPosition = new Vector3D(
+                (localPosition.x() - mapCenterX) * scale,
+                localPosition.y() + planet.radius(),
+                (localPosition.z() - mapCenterZ) * scale);
         if (localVelocity != null && localVelocity.lengthSquared() < 1e-5) {
             localVelocity = new Vector3d(0, 1, 0);
         }

--- a/src/main/java/dev/devce/rocketnautics/compat/computercraft/SputnikPeripheral.java
+++ b/src/main/java/dev/devce/rocketnautics/compat/computercraft/SputnikPeripheral.java
@@ -3,8 +3,14 @@ package dev.devce.rocketnautics.compat.computercraft;
 import dan200.computercraft.api.lua.LuaFunction;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import dev.devce.rocketnautics.content.blocks.SputnikBlockEntity;
+import dev.devce.rocketnautics.content.orbit.DeepSpaceData;
+import dev.devce.rocketnautics.content.orbit.DeepSpaceInstance;
+import dev.devce.rocketnautics.content.orbit.universe.DeepSpacePosition;
 import dev.devce.rocketnautics.content.physics.GlobalSpacePhysicsHandler;
 import dev.ryanhcode.sable.physics.config.dimension_physics.DimensionPhysicsData;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.phys.Vec3;
+import org.hipparchus.geometry.euclidean.threed.Vector3D;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,7 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 import dev.ryanhcode.sable.sublevel.ServerSubLevel;
 import org.joml.Vector3d;
-import org.joml.Quaterniond;
+import org.orekit.utils.TimeStampedPVCoordinates;
 
 public class SputnikPeripheral implements IPeripheral {
     private final SputnikBlockEntity sputnik;
@@ -73,6 +79,7 @@ public class SputnikPeripheral implements IPeripheral {
     @LuaFunction(mainThread = true)
     public final Map<String, Object> getPhysics() {
         Map<String, Object> data = new HashMap<>();
+        data.put("space", buildSpaceData());
         if (sputnik.getLevel() == null) return data;
 
         var subLevel = dev.ryanhcode.sable.Sable.HELPER.getContaining(sputnik.getLevel(), sputnik.getBlockPos());
@@ -117,5 +124,83 @@ public class SputnikPeripheral implements IPeripheral {
         }
 
         return data;
+    }
+
+    private Map<String, Object> buildSpaceData() {
+        try {
+            if (sputnik.getLevel() == null) return buildUnavailableSpaceData();
+
+            MinecraftServer server = sputnik.getLevel().getServer();
+            if (server == null || DeepSpaceData.tooSoon(server)) return buildUnavailableSpaceData();
+
+            Vector3d global = sputnik.getGlobalPos();
+            if (global == null) return buildUnavailableSpaceData();
+
+            DeepSpaceData deepSpaceData = DeepSpaceData.getInstance(server);
+            if (deepSpaceData == null) return buildUnavailableSpaceData();
+
+            DeepSpaceInstance instance = deepSpaceData.getInstanceForPos((int) global.x, (int) global.z);
+            if (instance == null || instance.isCorrupted() || !instance.boundingBox().contains(new Vec3(global.x, global.y, global.z))) {
+                return buildUnavailableSpaceData();
+            }
+
+            DeepSpacePosition spacePos = instance.getPosition();
+            if (spacePos == null || spacePos.getFrame() == null) return buildUnavailableSpaceData();
+
+            TimeStampedPVCoordinates pv = spacePos.getCurrentPVCoords();
+            if (pv == null || pv.getPosition() == null || pv.getVelocity() == null) {
+                return buildUnavailableSpaceData();
+            }
+
+            Vector3D pos = pv.getPosition();
+            Vector3D vel = pv.getVelocity();
+
+            Map<String, Object> space = new HashMap<>();
+            space.put("available", true);
+            space.put("frame", spacePos.getFrame().getName());
+
+            Map<String, Double> position = new HashMap<>();
+            position.put("x", pos.getX());
+            position.put("y", pos.getY());
+            position.put("z", pos.getZ());
+            space.put("position", position);
+
+            Map<String, Double> velocity = new HashMap<>();
+            velocity.put("x", vel.getX());
+            velocity.put("y", vel.getY());
+            velocity.put("z", vel.getZ());
+            velocity.put("speed", vel.getNorm());
+            space.put("velocity", velocity);
+
+            space.put("velocityAngles", velocityToYawPitch(vel.getX(), vel.getY(), vel.getZ()));
+            return space;
+        } catch (RuntimeException ignored) {
+            return buildUnavailableSpaceData();
+        }
+    }
+
+    private static Map<String, Object> buildUnavailableSpaceData() {
+        Map<String, Object> space = new HashMap<>();
+        space.put("available", false);
+        return space;
+    }
+
+    private static Map<String, Double> velocityToYawPitch(double vx, double vy, double vz) {
+        double horizontal = Math.sqrt(vx * vx + vz * vz);
+
+        Map<String, Double> angles = new HashMap<>();
+
+        if (horizontal < 1e-9 && Math.abs(vy) < 1e-9) {
+            angles.put("yaw", 0.0);
+            angles.put("pitch", 0.0);
+            return angles;
+        }
+
+        double yaw = Math.toDegrees(Math.atan2(-vx, vz));
+        double pitch = Math.toDegrees(Math.atan2(-vy, horizontal));
+
+        angles.put("yaw", yaw);
+        angles.put("pitch", pitch);
+        return angles;
     }
 }

--- a/src/main/java/dev/devce/rocketnautics/content/orbit/universe/PlanetDimensionData.java
+++ b/src/main/java/dev/devce/rocketnautics/content/orbit/universe/PlanetDimensionData.java
@@ -18,7 +18,12 @@ import java.util.*;
 public record PlanetDimensionData(@NotNull ResourceKey<Level> key, @NotNull AllowedTransfer allowedTransfer,
                                   int transitionHeight, @NotNull Int2ObjectSortedMap<EnumSet<AtmosphereFlags>> atmosphere,
                                   boolean renderUniverseInDimension, int dimensionDayTimeControllerID,
-                                  boolean applyGravityCorrectionToEntities, @NotNull BezierResourceFunction entityDragMultiplier) {
+                                  boolean applyGravityCorrectionToEntities, @NotNull BezierResourceFunction entityDragMultiplier,
+                                  double surfaceMapCenterX, double surfaceMapCenterZ, double surfaceMapRadius) {
+
+    public static final double DEFAULT_SURFACE_MAP_CENTER_X = 0.0;
+    public static final double DEFAULT_SURFACE_MAP_CENTER_Z = 0.0;
+    public static final double DEFAULT_SURFACE_MAP_RADIUS = 30_000_000.0;
 
     private static final StreamCodec<FriendlyByteBuf, BezierResourceFunction.BezierPoint> pointCodec = StreamCodec.of(
             (buf, v) -> {
@@ -49,6 +54,9 @@ public record PlanetDimensionData(@NotNull ResourceKey<Level> key, @NotNull Allo
         buf.writeVarInt(dimensionDayTimeControllerID);
         buf.writeBoolean(applyGravityCorrectionToEntities);
         buf.writeCollection(entityDragMultiplier.getPoints(), pointCodec);
+        buf.writeDouble(surfaceMapCenterX);
+        buf.writeDouble(surfaceMapCenterZ);
+        buf.writeDouble(surfaceMapRadius);
     }
 
     public static PlanetDimensionData read(FriendlyByteBuf buf) {
@@ -60,10 +68,14 @@ public record PlanetDimensionData(@NotNull ResourceKey<Level> key, @NotNull Allo
         int controlDimensionDayTimeID = buf.readVarInt();
         boolean applyGravityCorrectionToEntities = buf.readBoolean();
         ArrayList<BezierResourceFunction.BezierPoint> entityDragPoints = buf.readCollection(ArrayList::new, pointCodec);
+        double surfaceMapCenterX = buf.readDouble();
+        double surfaceMapCenterZ = buf.readDouble();
+        double surfaceMapRadius = buf.readDouble();
         return new PlanetDimensionData(key, allowedTransfer,
                 transitionHeight, new Int2ObjectAVLTreeMap<>(map),
                 renderUniverseInDimension, controlDimensionDayTimeID,
-                applyGravityCorrectionToEntities, entityDragPoints.isEmpty() ? EMPTY_BEZIER : new BezierResourceFunction(entityDragPoints));
+                applyGravityCorrectionToEntities, entityDragPoints.isEmpty() ? EMPTY_BEZIER : new BezierResourceFunction(entityDragPoints),
+                surfaceMapCenterX, surfaceMapCenterZ, surfaceMapRadius);
     }
 
 }

--- a/src/main/java/dev/devce/rocketnautics/content/orbit/universe/builder/PlanetDefinitionBuilder.java
+++ b/src/main/java/dev/devce/rocketnautics/content/orbit/universe/builder/PlanetDefinitionBuilder.java
@@ -57,6 +57,9 @@ public class PlanetDefinitionBuilder {
     public Optional<String> dimensionDayTimeControllerName = Optional.empty();
     public Optional<Boolean> applyGravityCorrectionToEntities = Optional.empty();
     public Optional<BezierResourceFunction> entityDragMultiplier = Optional.empty();
+    public Optional<Double> surfaceMapCenterX = Optional.empty();
+    public Optional<Double> surfaceMapCenterZ = Optional.empty();
+    public Optional<Double> surfaceMapRadius = Optional.empty();
     // planet extras
     public Optional<Boolean> clouds = Optional.empty();
     public Optional<Boolean> star = Optional.empty();
@@ -110,6 +113,9 @@ public class PlanetDefinitionBuilder {
             dimensionDayTimeControllerName.ifPresent(dependencies::add);
             this.applyGravityCorrectionToEntities = dimData.get().applyGravityCorrectionToEntities();
             this.entityDragMultiplier = dimData.get().entityDragMultiplier();
+            this.surfaceMapCenterX = dimData.get().surfaceMapCenterX();
+            this.surfaceMapCenterZ = dimData.get().surfaceMapCenterZ();
+            this.surfaceMapRadius = dimData.get().surfaceMapRadius();
         }
         if (extras.isPresent()) {
             this.clouds = extras.get().clouds();
@@ -141,7 +147,7 @@ public class PlanetDefinitionBuilder {
     }
 
     protected Optional<SerializableDimensionData> serializeDimensionData() {
-        return SerializableDimensionData.of(linkedDimension, allowedTransfer, transferHeight, atmosphere, renderUniverseInDimension, dimensionDayTimeControllerName, applyGravityCorrectionToEntities, entityDragMultiplier);
+        return SerializableDimensionData.of(linkedDimension, allowedTransfer, transferHeight, atmosphere, renderUniverseInDimension, dimensionDayTimeControllerName, applyGravityCorrectionToEntities, entityDragMultiplier, surfaceMapCenterX, surfaceMapCenterZ, surfaceMapRadius);
     }
 
     protected Optional<SerializablePlanetExtras> serializePlanetExtras() {
@@ -219,7 +225,10 @@ public class PlanetDefinitionBuilder {
                 transferHeight.orElse(20_000),
                 atmosphere.map(m -> (Int2ObjectSortedMap<EnumSet<AtmosphereFlags>>) new Int2ObjectAVLTreeMap<>(m)).orElse(Int2ObjectSortedMaps.emptyMap()), // bake into an AVL map for improved search performance
                 renderUniverseInDimension.orElse(false), id, applyGravityCorrectionToEntities.orElse(false),
-                entityDragMultiplier.orElse(PlanetDimensionData.EMPTY_BEZIER));
+                entityDragMultiplier.orElse(PlanetDimensionData.EMPTY_BEZIER),
+                surfaceMapCenterX.orElse(PlanetDimensionData.DEFAULT_SURFACE_MAP_CENTER_X),
+                surfaceMapCenterZ.orElse(PlanetDimensionData.DEFAULT_SURFACE_MAP_CENTER_Z),
+                surfaceMapRadius.orElse(PlanetDimensionData.DEFAULT_SURFACE_MAP_RADIUS));
     }
 
     protected PlanetExtras constructExtras(UniverseDefinitionBuilder destination) {
@@ -261,6 +270,25 @@ public class PlanetDefinitionBuilder {
     public PlanetDefinitionBuilder setApplyGravityCorrectionToEntities(boolean applyGravityCorrectionToEntities) {
         this.applyGravityCorrectionToEntities = Optional.of(applyGravityCorrectionToEntities);
         return this;
+    }
+
+    public PlanetDefinitionBuilder setSurfaceMapCenter(double x, double z) {
+        this.surfaceMapCenterX = Optional.of(x);
+        this.surfaceMapCenterZ = Optional.of(z);
+        return this;
+    }
+
+    public PlanetDefinitionBuilder setSurfaceMapRadius(double radius) {
+        if (radius <= 0) {
+            throw new IllegalArgumentException("Surface map radius must be positive!");
+        }
+        this.surfaceMapRadius = Optional.of(radius);
+        return this;
+    }
+
+    public PlanetDefinitionBuilder setSurfaceMap(double centerX, double centerZ, double radius) {
+        setSurfaceMapCenter(centerX, centerZ);
+        return setSurfaceMapRadius(radius);
     }
 
     public PlanetDefinitionBuilder setTextureOverride(ResourceLocation textureAlternative) {

--- a/src/main/java/dev/devce/rocketnautics/content/orbit/universe/builder/SerializableDimensionData.java
+++ b/src/main/java/dev/devce/rocketnautics/content/orbit/universe/builder/SerializableDimensionData.java
@@ -1,6 +1,7 @@
 package dev.devce.rocketnautics.content.orbit.universe.builder;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.devce.rocketnautics.api.orbit.AllowedTransfer;
 import dev.devce.rocketnautics.api.orbit.AtmosphereFlags;
@@ -16,7 +17,12 @@ import java.util.*;
 public record SerializableDimensionData(Optional<ResourceKey<Level>> key, Optional<AllowedTransfer> allowedTransfer,
                                         Optional<Integer> transitionHeight, Optional<Int2ObjectRBTreeMap<EnumSet<AtmosphereFlags>>> atmosphere,
                                         Optional<Boolean> renderUniverseInDimension, Optional<String> dimensionDayTimeControllerName,
-                                        Optional<Boolean> applyGravityCorrectionToEntities, Optional<BezierResourceFunction> entityDragMultiplier) {
+                                        Optional<Boolean> applyGravityCorrectionToEntities, Optional<BezierResourceFunction> entityDragMultiplier,
+                                        Optional<Double> surfaceMapCenterX, Optional<Double> surfaceMapCenterZ, Optional<Double> surfaceMapRadius) {
+    private static final Codec<Double> POSITIVE_DOUBLE = Codec.DOUBLE.validate(value -> value > 0
+            ? DataResult.success(value)
+            : DataResult.error(() -> "Value must be positive: " + value));
+
     public static final Codec<SerializableDimensionData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Level.RESOURCE_KEY_CODEC.optionalFieldOf("linked_dimension").forGetter(p -> p.key),
             AllowedTransfer.CODEC.optionalFieldOf("allowed_transfer").forGetter(p -> p.allowedTransfer),
@@ -25,20 +31,25 @@ public record SerializableDimensionData(Optional<ResourceKey<Level>> key, Option
             Codec.BOOL.optionalFieldOf("render_universe_in_dimension").forGetter(p -> p.renderUniverseInDimension),
             Codec.STRING.optionalFieldOf("dimension_day_time_controller_name").forGetter(p -> p.dimensionDayTimeControllerName),
             Codec.BOOL.optionalFieldOf("apply_gravity_correction_to_entities_in_dimension").forGetter(p -> p.applyGravityCorrectionToEntities),
-            BezierResourceFunction.CODEC.optionalFieldOf("entity_drag_multiplier").forGetter(p -> p.entityDragMultiplier)
+            BezierResourceFunction.CODEC.optionalFieldOf("entity_drag_multiplier").forGetter(p -> p.entityDragMultiplier),
+            Codec.DOUBLE.optionalFieldOf("surface_map_center_x").forGetter(p -> p.surfaceMapCenterX),
+            Codec.DOUBLE.optionalFieldOf("surface_map_center_z").forGetter(p -> p.surfaceMapCenterZ),
+            POSITIVE_DOUBLE.optionalFieldOf("surface_map_radius").forGetter(p -> p.surfaceMapRadius)
     ).apply(instance, SerializableDimensionData::new));
 
     public static Optional<SerializableDimensionData> of(Optional<ResourceKey<Level>> key, Optional<AllowedTransfer> allowedTransfer,
                                                          Optional<Integer> transitionHeight, Optional<Int2ObjectRBTreeMap<EnumSet<AtmosphereFlags>>> atmosphere,
                                                          Optional<Boolean> renderUniverseInDimension, Optional<String> dimensionDayTimeControllerName,
-                                                         Optional<Boolean> applyGravityCorrectionToEntities, Optional<BezierResourceFunction> entityDragMultiplier) {
+                                                         Optional<Boolean> applyGravityCorrectionToEntities, Optional<BezierResourceFunction> entityDragMultiplier,
+                                                         Optional<Double> surfaceMapCenterX, Optional<Double> surfaceMapCenterZ, Optional<Double> surfaceMapRadius) {
         if (key.isEmpty() && allowedTransfer.isEmpty() &&
                 transitionHeight.isEmpty() && atmosphere.isEmpty() &&
                 renderUniverseInDimension.isEmpty() && dimensionDayTimeControllerName.isEmpty() &&
-                applyGravityCorrectionToEntities.isEmpty() && entityDragMultiplier.isEmpty()) {
+                applyGravityCorrectionToEntities.isEmpty() && entityDragMultiplier.isEmpty() &&
+                surfaceMapCenterX.isEmpty() && surfaceMapCenterZ.isEmpty() && surfaceMapRadius.isEmpty()) {
             return Optional.empty();
         }
-        return Optional.of(new SerializableDimensionData(key, allowedTransfer, transitionHeight, atmosphere, renderUniverseInDimension, dimensionDayTimeControllerName, applyGravityCorrectionToEntities, entityDragMultiplier));
+        return Optional.of(new SerializableDimensionData(key, allowedTransfer, transitionHeight, atmosphere, renderUniverseInDimension, dimensionDayTimeControllerName, applyGravityCorrectionToEntities, entityDragMultiplier, surfaceMapCenterX, surfaceMapCenterZ, surfaceMapRadius));
     }
 
     private static EnumSet<AtmosphereFlags> properCopy(Collection<AtmosphereFlags> collection) {

--- a/src/main/java/dev/devce/rocketnautics/content/physics/SpaceTransitionHandler.java
+++ b/src/main/java/dev/devce/rocketnautics/content/physics/SpaceTransitionHandler.java
@@ -9,6 +9,7 @@ import dev.devce.rocketnautics.content.RocketDimensions;
 import dev.devce.rocketnautics.content.orbit.DeepSpaceData;
 import dev.devce.rocketnautics.content.orbit.DeepSpaceInstance;
 import dev.devce.rocketnautics.content.orbit.universe.CubePlanet;
+import dev.devce.rocketnautics.content.orbit.universe.PlanetDimensionData;
 import dev.devce.rocketnautics.mixin.DistanceManagerAccessor;
 import dev.devce.rocketnautics.network.SeamlessTransitionPayload;
 import dev.egg.SubLevelWarper;
@@ -114,7 +115,8 @@ public class SpaceTransitionHandler {
     public static void exitDeepSpace(MinecraftServer server, CubePlanet destination, Rotation correctionRotation, Vector3D positionInPlanetFrame, @NotNull Direction.Axis majorAxis, DeepSpaceInstance instance, Runnable afterFinished) {
         assert destination.linkedDimension() != null;
         final ServerLevel deepSpace = server.getLevel(RocketDimensions.DEEP_SPACE);
-        double scaleFactor = 30_000_000 / destination.radius();
+        PlanetDimensionData dimensionData = destination.linkedDimension();
+        double scaleFactor = dimensionData.surfaceMapRadius() / destination.radius();
         double targetHeight = destination.linkedDimension().transitionHeight() - SpaceTransitionHandler.TRANSITION_SAFE_OFFSET;
         Vector3D p = correctionRotation.applyInverseTo(positionInPlanetFrame);
         Vector3D axi;
@@ -157,6 +159,8 @@ public class SpaceTransitionHandler {
                 yield new Vector3d(p.getX() * scaleFactor, targetHeight, p.getZ() * scaleFactor);
             }
         };
+        destPos.x += dimensionData.surfaceMapCenterX();
+        destPos.z += dimensionData.surfaceMapCenterZ();
         ServerLevel destLevel = server.getLevel(destination.linkedDimension().key());
         if (destLevel == null) return;
         Rotation rotation = correctionRotation.compose(new Rotation(Vector3D.PLUS_J, axi), RotationConvention.VECTOR_OPERATOR);


### PR DESCRIPTION
Adds configurable per-planet surface map mapping for linked dimensions.

Previously, planet surface mapping assumed every linked dimension used a map centered at X/Z `0, 0` with radius `30,000,000`. This PR adds optional `dimension_data` fields:

- `surface_map_center_x`
- `surface_map_center_z`
- `surface_map_radius`

If these fields are omitted, the old behavior is preserved exactly.

## Why

Servers with smaller world borders or non-zero map centers can now configure reentry/space transition coordinates without hardcoding the vanilla world border assumption.

Example:

```json
"surface_map_center_x": 2000.0,
"surface_map_center_z": 2000.0,
"surface_map_radius": 10000.0
```