### PR TITLE
Add orbital position and velocity to Sputnik getPhysics

### DIFF
--- a/src/main/java/dev/devce/rocketnautics/compat/computercraft/SputnikPeripheral.java
+++ b/src/main/java/dev/devce/rocketnautics/compat/computercraft/SputnikPeripheral.java
@@ -3,8 +3,14 @@ package dev.devce.rocketnautics.compat.computercraft;
 import dan200.computercraft.api.lua.LuaFunction;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import dev.devce.rocketnautics.content.blocks.SputnikBlockEntity;
+import dev.devce.rocketnautics.content.orbit.DeepSpaceData;
+import dev.devce.rocketnautics.content.orbit.DeepSpaceInstance;
+import dev.devce.rocketnautics.content.orbit.universe.DeepSpacePosition;
 import dev.devce.rocketnautics.content.physics.GlobalSpacePhysicsHandler;
 import dev.ryanhcode.sable.physics.config.dimension_physics.DimensionPhysicsData;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.phys.Vec3;
+import org.hipparchus.geometry.euclidean.threed.Vector3D;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,7 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 import dev.ryanhcode.sable.sublevel.ServerSubLevel;
 import org.joml.Vector3d;
-import org.joml.Quaterniond;
+import org.orekit.utils.TimeStampedPVCoordinates;
 
 public class SputnikPeripheral implements IPeripheral {
     private final SputnikBlockEntity sputnik;
@@ -73,6 +79,7 @@ public class SputnikPeripheral implements IPeripheral {
     @LuaFunction(mainThread = true)
     public final Map<String, Object> getPhysics() {
         Map<String, Object> data = new HashMap<>();
+        data.put("space", buildSpaceData());
         if (sputnik.getLevel() == null) return data;
 
         var subLevel = dev.ryanhcode.sable.Sable.HELPER.getContaining(sputnik.getLevel(), sputnik.getBlockPos());
@@ -117,5 +124,83 @@ public class SputnikPeripheral implements IPeripheral {
         }
 
         return data;
+    }
+
+    private Map<String, Object> buildSpaceData() {
+        try {
+            if (sputnik.getLevel() == null) return buildUnavailableSpaceData();
+
+            MinecraftServer server = sputnik.getLevel().getServer();
+            if (server == null || DeepSpaceData.tooSoon(server)) return buildUnavailableSpaceData();
+
+            Vector3d global = sputnik.getGlobalPos();
+            if (global == null) return buildUnavailableSpaceData();
+
+            DeepSpaceData deepSpaceData = DeepSpaceData.getInstance(server);
+            if (deepSpaceData == null) return buildUnavailableSpaceData();
+
+            DeepSpaceInstance instance = deepSpaceData.getInstanceForPos((int) global.x, (int) global.z);
+            if (instance == null || instance.isCorrupted() || !instance.boundingBox().contains(new Vec3(global.x, global.y, global.z))) {
+                return buildUnavailableSpaceData();
+            }
+
+            DeepSpacePosition spacePos = instance.getPosition();
+            if (spacePos == null || spacePos.getFrame() == null) return buildUnavailableSpaceData();
+
+            TimeStampedPVCoordinates pv = spacePos.getCurrentPVCoords();
+            if (pv == null || pv.getPosition() == null || pv.getVelocity() == null) {
+                return buildUnavailableSpaceData();
+            }
+
+            Vector3D pos = pv.getPosition();
+            Vector3D vel = pv.getVelocity();
+
+            Map<String, Object> space = new HashMap<>();
+            space.put("available", true);
+            space.put("frame", spacePos.getFrame().getName());
+
+            Map<String, Double> position = new HashMap<>();
+            position.put("x", pos.getX());
+            position.put("y", pos.getY());
+            position.put("z", pos.getZ());
+            space.put("position", position);
+
+            Map<String, Double> velocity = new HashMap<>();
+            velocity.put("x", vel.getX());
+            velocity.put("y", vel.getY());
+            velocity.put("z", vel.getZ());
+            velocity.put("speed", vel.getNorm());
+            space.put("velocity", velocity);
+
+            space.put("velocityAngles", velocityToYawPitch(vel.getX(), vel.getY(), vel.getZ()));
+            return space;
+        } catch (RuntimeException ignored) {
+            return buildUnavailableSpaceData();
+        }
+    }
+
+    private static Map<String, Object> buildUnavailableSpaceData() {
+        Map<String, Object> space = new HashMap<>();
+        space.put("available", false);
+        return space;
+    }
+
+    private static Map<String, Double> velocityToYawPitch(double vx, double vy, double vz) {
+        double horizontal = Math.sqrt(vx * vx + vz * vz);
+
+        Map<String, Double> angles = new HashMap<>();
+
+        if (horizontal < 1e-9 && Math.abs(vy) < 1e-9) {
+            angles.put("yaw", 0.0);
+            angles.put("pitch", 0.0);
+            return angles;
+        }
+
+        double yaw = Math.toDegrees(Math.atan2(-vx, vz));
+        double pitch = Math.toDegrees(Math.atan2(-vy, horizontal));
+
+        angles.put("yaw", yaw);
+        angles.put("pitch", pitch);
+        return angles;
     }
 }


### PR DESCRIPTION
Adds deep-space telemetry to the Sputnik peripheral `getPhysics()` output.

This keeps the existing local physics fields unchanged and adds a new `space` section with:
- availability flag(deep space checker)
- orbital frame name
- deep space position
- deep space velocity(x/y/z) and speed
- yaw/pitch for the orbital velocity vector

This allows CC computers to read orbital telemetry directly from Sputnik.