### PR TITLE
C2ME 0.4.0 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
 configurations {
     shade
     implementation.extendsFrom(shade)
+    jarExtraction
 }
 
 repositories {
@@ -94,6 +95,21 @@ neoForge {
     }
 }
 
+tasks.register('extractInnerJar', Copy) {
+    // Take the downloaded outer JAR file and treat it as a zip tree
+    from {
+        configurations.jarExtraction.collect { zipTree(it) }
+    }
+    // Filter specifically for your nested JAR file
+    include "**/c2me-neoforge-opts-dfc-mc1.21.1-0.4.0-alpha.0.101.jar"
+
+    // Flatten the directory structure so it drops straight into our target folder
+    eachFile { path = name }
+    includeEmptyDirs = false
+
+    into layout.buildDirectory.dir("extracted-jars")
+}
+
 dependencies {
     
     implementation("com.simibubi.create:create-${minecraft_version}:${create_version}") { transitive = false }
@@ -112,6 +128,12 @@ dependencies {
     implementation("dev.simulated_team.simulated:simulated-neoforge-${minecraft_version}:${simulated_version}") { transitive = false }
     implementation("dev.eriksonn.aeronautics:aeronautics-neoforge-${minecraft_version}:${aeronautics_version}") { transitive = false }
     implementation("foundry.veil:veil-neoforge-${minecraft_version}:4.1.1")
+
+    runtimeOnly("maven.modrinth:c2me-neoforge:0.4.0-alpha.0.101+1.21.1")
+    jarExtraction("maven.modrinth:c2me-neoforge:0.4.0-alpha.0.101+1.21.1")
+    compileOnly fileTree(layout.buildDirectory.dir("extracted-jars")) {
+        builtBy(extractInnerJar)
+    }
     
     compileOnly("mezz.jei:jei-1.21.1-common-api:${jei_version}")
     compileOnly("mezz.jei:jei-1.21.1-neoforge-api:${jei_version}")

--- a/src/main/java/dev/devce/rocketnautics/content/world/RilleWorldCarver.java
+++ b/src/main/java/dev/devce/rocketnautics/content/world/RilleWorldCarver.java
@@ -29,7 +29,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 
 public class RilleWorldCarver extends WorldCarver<RilleCarverConfiguration> {
-    protected static final WorldgenRandom random = new WorldgenRandom(RandomSource.create(0));
+    protected static final ThreadLocal<WorldgenRandom> random = ThreadLocal.withInitial(() -> new WorldgenRandom(RandomSource.create(0)));
 
     protected final Map<RilleCarverConfiguration, LoadingCache<ChunkPos, ChunkData>> caches = new Object2ObjectOpenHashMap<>();
 
@@ -135,6 +135,7 @@ public class RilleWorldCarver extends WorldCarver<RilleCarverConfiguration> {
 
     protected RandomSource randomForChunk(RilleCarverConfiguration configuration, ChunkPos pos) {
         // TODO add the world seed to salt somehow
+        WorldgenRandom random = RilleWorldCarver.random.get();
         random.setLargeFeatureSeed(configuration.salt, pos.x, pos.z);
         return random.fork();
     }

--- a/src/main/java/dev/devce/rocketnautics/mixin/RocketMixinPlugin.java
+++ b/src/main/java/dev/devce/rocketnautics/mixin/RocketMixinPlugin.java
@@ -1,0 +1,43 @@
+package dev.devce.rocketnautics.mixin;
+
+import dev.devce.rocketnautics.mixin.compat.C2MEDensityFunctionFixer;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.loading.FMLLoader;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class RocketMixinPlugin implements IMixinConfigPlugin {
+    @Override
+    public void onLoad(String s) {}
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String s, String s1) {
+        if ("dev.devce.rocketnautics.mixin.compat.C2MEDensityFunctionFixer".equals(s1)) {
+            return FMLLoader.getLoadingModList().getModFileById("c2me") != null;
+        }
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> set, Set<String> set1) {}
+
+    @Override
+    public List<String> getMixins() {
+        return List.of();
+    }
+
+    @Override
+    public void preApply(String s, ClassNode classNode, String s1, IMixinInfo iMixinInfo) {}
+
+    @Override
+    public void postApply(String s, ClassNode classNode, String s1, IMixinInfo iMixinInfo) {}
+}

--- a/src/main/java/dev/devce/rocketnautics/mixin/compat/C2MEDensityFunctionFixer.java
+++ b/src/main/java/dev/devce/rocketnautics/mixin/compat/C2MEDensityFunctionFixer.java
@@ -1,0 +1,24 @@
+package dev.devce.rocketnautics.mixin.compat;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.binary.MulNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.ConstantNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.CoordinateNode;
+import com.ishland.c2me.opts.dfc.common.ast.noise.GenericShiftedNoiseNode;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import dev.devce.rocketnautics.content.world.StretchedNoise;
+import net.minecraft.world.level.levelgen.DensityFunction;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(com.ishland.c2me.opts.dfc.common.ast.McToAst.class)
+public class C2MEDensityFunctionFixer {
+
+    @ModifyReturnValue(method = "toAst", at = @At(value = "RETURN"))
+    private static AstNode rocketnautics$adaptStretchedNoise(AstNode original, DensityFunction df) {
+        if (df instanceof StretchedNoise(DensityFunction.NoiseHolder noise, double xScale, double yScale, double zScale)) {
+            return new GenericShiftedNoiseNode(new MulNode(CoordinateNode.AXIS_X, new ConstantNode(xScale)), new MulNode(CoordinateNode.AXIS_Y, new ConstantNode(yScale)), new MulNode(CoordinateNode.AXIS_Z, new ConstantNode(zScale)), noise);
+        }
+        return original;
+    }
+}

--- a/src/main/resources/rocketnautics.mixins.json
+++ b/src/main/resources/rocketnautics.mixins.json
@@ -3,10 +3,11 @@
   "minVersion": "0.8",
   "package": "dev.devce.rocketnautics.mixin",
   "compatibilityLevel": "JAVA_21",
+  "plugin": "dev.devce.rocketnautics.mixin.RocketMixinPlugin",
   "mixins": [
     "BacktankUtilMixin",
-    "CarvingContextMixin",
     "BucketItemAccessor",
+    "CarvingContextMixin",
     "DistanceManagerAccessor",
     "DivingHelmetItemMixin",
     "EntityMixin",
@@ -21,7 +22,8 @@
     "RapierFixedConstraintHandleMixin",
     "RapierFreeConstraintHandleMixin",
     "RapierGenericConstraintHandleMixin",
-    "RapierRotaryConstraintHandleMixin"
+    "RapierRotaryConstraintHandleMixin",
+    "compat.C2MEDensityFunctionFixer"
   ],
   "client": [
     "ClientLevelMixin",


### PR DESCRIPTION
### What Changed
Adds compatibility for our custom density function with the [c2me 0.4.0 backport](https://modrinth.com/mod/c2me-neoforge/version/0.4.0-alpha.0.101+1.21.1).
Fixes an issue where we assumed singlethreaded chunkloading.
### Why this change
Previously, our custom density function would simply crash c2me OpenCL immediately as they do not support custom density functions, and it was impossible to fix. With 0.4.0, we no longer crash immediately as they have created a delegate node, but presumably without much speed benefit. This PR adds a mixin that explicitly converts our custom density function to an OpenCL AST node, presumably bringing back the speed benefit.