### PR TITLE
Distant Horizons Compat

### DIFF
--- a/src/main/java/dev/devce/rocketnautics/DistantHorizonsCompat.java
+++ b/src/main/java/dev/devce/rocketnautics/DistantHorizonsCompat.java
@@ -1,0 +1,57 @@
+package devce.rocketnautics;
+
+import com.seibel.distanthorizons.api.DhApi.Delayed;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.neoforged.neoforge.client.event.ClientTickEvent;
+
+public class DistantHorizonsCompat {
+    private static final double DH_UNLOAD_Y = 1049.0;
+    private static boolean isDhDisabled = false;
+
+    public static void onClientTick(ClientTickEvent.Post event) {
+        Minecraft mc = Minecraft.getInstance();
+        LocalPlayer player = mc.player;
+        if (player != null && isDhReady()) {
+            if (player.getY() > 1049.0) {
+                if (!isDhDisabled) {
+                    unloadDistantHorizonsChunks();
+                    isDhDisabled = true;
+                }
+            } else if (isDhDisabled || shouldForceLoadDistantHorizonsChunks()) {
+                forceLoadDistantHorizonsChunks();
+                isDhDisabled = false;
+            }
+        }
+    }
+
+    private static boolean isDhReady() {
+        return Delayed.configs != null && Delayed.renderProxy != null && Delayed.worldProxy != null && Delayed.worldProxy.worldLoaded();
+    }
+
+    private static void unloadDistantHorizonsChunks() {
+        Delayed.configs.graphics().renderingEnabled().setValue(false);
+        Delayed.configs.worldGenerator().enableDistantWorldGeneration().setValue(false);
+        Delayed.worldProxy.setReadOnly(true);
+        Delayed.renderProxy.clearRenderDataCache();
+    }
+
+    private static boolean shouldForceLoadDistantHorizonsChunks() {
+        return !(Boolean)Delayed.configs.graphics().renderingEnabled().getValue() || !(Boolean)Delayed.configs.worldGenerator().enableDistantWorldGeneration().getValue() || getCurrentReadOnly();
+    }
+
+    private static boolean getCurrentReadOnly() {
+        try {
+            return Delayed.worldProxy.getReadOnly();
+        } catch (IllegalStateException var1) {
+            return false;
+        }
+    }
+
+    private static void forceLoadDistantHorizonsChunks() {
+        Delayed.configs.graphics().renderingEnabled().setValue(true);
+        Delayed.configs.worldGenerator().enableDistantWorldGeneration().setValue(true);
+        Delayed.worldProxy.setReadOnly(false);
+        Delayed.renderProxy.clearRenderDataCache();
+    }
+}

--- a/src/main/java/dev/devce/rocketnautics/RocketNautics.java
+++ b/src/main/java/dev/devce/rocketnautics/RocketNautics.java
@@ -101,7 +101,12 @@ public class RocketNautics {
 
         modEventBus.addListener(this::setup);
         NeoForge.EVENT_BUS.register(this);
-
+if (net.neoforged.fml.ModList.get().isLoaded("distant_horizons")) {
+            net.neoforged.neoforge.common.NeoForge.EVENT_BUS.addListener(
+                net.neoforged.neoforge.client.event.ClientTickEvent.Post.class, 
+                DistantHorizonsCompat::onClientTick
+            );
+        }
         // Initialize physics and game mechanics handlers
         GlobalSpacePhysicsHandler.init();
         dev.devce.rocketnautics.content.physics.AsteroidSpawner.init();


### PR DESCRIPTION
This PR fixes an issue where Distant Horizons (DH) chunks would fail to unload properly when entering the stratosphere above Y 1049, and reload when going back below Y 1049.

The compatibility logic has been isolated into a separate class (`DistantHorizonsCompat`) and is safely registered dynamically only if the Distant Horizons mod is loaded. This ensures that the mod remains fully playable and won't crash for users who do not use Distant Horizons.