### PR TITLE
fix: initialize PackageLib before Bit32Lib in Lua sandbox, issue  #121

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,10 @@ tasks.register('extractInnerJar', Copy) {
 
 dependencies {
 
+    testImplementation(platform('org.junit:junit-bom:5.11.4'))
+    testImplementation('org.junit.jupiter:junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
+
     implementation("com.simibubi.create:create-${minecraft_version}:${create_version}") { transitive = false }
     implementation("net.createmod.ponder:ponder-neoforge:${ponder_version}+mc${minecraft_version}")
     compileOnly("dev.engine-room.flywheel:flywheel-neoforge-api-${minecraft_version}:${flywheel_version}")
@@ -169,6 +173,10 @@ dependencies {
 }
 
 sourceSets.main.resources { srcDir 'src/generated/resources' }
+
+tasks.named('test', Test) {
+    useJUnitPlatform()
+}
 
 // --- Fix for CreateMinecraftArtifacts missing manifest ---
 // Generates an empty manifest file expected by the NeoForge moddev plugin.

--- a/src/main/java/dev/devce/rocketnautics/lua/LuaSandbox.java
+++ b/src/main/java/dev/devce/rocketnautics/lua/LuaSandbox.java
@@ -23,6 +23,8 @@ public final class LuaSandbox {
 
         // 1. Load only safe standard libraries
         globals.load(new JseBaseLib());
+        // Bit32Lib registers itself in package.loaded during initialization.
+        globals.load(new PackageLib());
         globals.load(new Bit32Lib());
         globals.load(new TableLib());
         globals.load(new StringLib());

--- a/src/test/java/dev/devce/rocketnautics/lua/LuaSandboxTest.java
+++ b/src/test/java/dev/devce/rocketnautics/lua/LuaSandboxTest.java
@@ -1,0 +1,24 @@
+package dev.devce.rocketnautics.lua;
+
+import org.junit.jupiter.api.Test;
+import org.luaj.vm2.Globals;
+import org.luaj.vm2.LuaValue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LuaSandboxTest {
+    @Test
+    void initializesBit32WithoutExposingPackageApis() {
+        Globals globals = LuaSandbox.createSandboxedGlobals();
+
+        assertEquals(1, globals.get("bit32").get("band").call(LuaValue.valueOf(3), LuaValue.valueOf(1)).checkint());
+        assertTrue(globals.get("package").isnil());
+        assertTrue(globals.get("require").isnil());
+        assertTrue(globals.get("os").isnil());
+        assertTrue(globals.get("io").isnil());
+        assertTrue(globals.get("luajava").isnil());
+        assertTrue(globals.get("debug").isnil());
+        assertTrue(globals.get("string").get("dump").isnil());
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the Sputnik Gyrodyne Control crash caused by LuaJ sandbox initialization.

`Bit32Lib` registers itself in `package.loaded`. The sandbox loaded `Bit32Lib` without first creating `package`, causing:

`LuaError: attempt to index ? (a nil value)`

Load `PackageLib` before `Bit32Lib`. `package` and all restricted APIs are still removed before scripts run.

## Tests
- Added `LuaSandboxTest`.
- Verifies `bit32.band(3, 1)` works.
- Verifies `package`, `require`, `os`, `io`, `luajava`, `debug`, and `string.dump` remain inaccessible.

## Why add a test
This bug was an initialization-order regression with no gameplay-specific requirement. A unit test is fast, directly reproduces the failing LuaJ call, and prevents future sandbox/security changes from breaking all Sputnik Lua nodes again.

Issue
Fixes issue #121